### PR TITLE
fix relative url in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](oci/tables)**
+- **[Table definitions & examples →](/plugins/turbot/oci/tables)**
 
 ## Get started
 


### PR DESCRIPTION
changed link in index.md to be qualified from the root of the website 

`oci/tables` to `/plugins/turbot/oci/tables`