### PR TITLE
Hydrate columns values did not populate in cloudguard tables in list call. Closes #123

### DIFF
--- a/docs/tables/oci_cloud_guard_detector_recipe.md
+++ b/docs/tables/oci_cloud_guard_detector_recipe.md
@@ -16,7 +16,7 @@ from
   oci_cloud_guard_detector_recipe;
 ```
 
-### List active detector recipes
+### List detector recipes which are not active
 
 ```sql
 select
@@ -27,7 +27,7 @@ select
 from
   oci_cloud_guard_detector_recipe
 where
-  lifecycle_state = 'ACTIVE';
+  lifecycle_state <> 'ACTIVE';
 ```
 
 ### List detector recipes with password related rules

--- a/docs/tables/oci_cloud_guard_managed_list.md
+++ b/docs/tables/oci_cloud_guard_managed_list.md
@@ -16,7 +16,7 @@ from
   oci_cloud_guard_managed_list;
 ```
 
-### List active managed lists
+### List managed lists which are not active
 
 ```sql
 select
@@ -27,5 +27,5 @@ select
 from
   oci_cloud_guard_managed_list
 where
-  lifecycle_state = 'ACTIVE';
+  lifecycle_state <> 'ACTIVE';
 ```

--- a/docs/tables/oci_cloud_guard_responder_recipe.md
+++ b/docs/tables/oci_cloud_guard_responder_recipe.md
@@ -16,7 +16,7 @@ from
   oci_cloud_guard_responder_recipe;
 ```
 
-### List active responder recipes
+### List responder recipes which are not active
 
 ```sql
 select
@@ -27,5 +27,5 @@ select
 from
   oci_cloud_guard_responder_recipe
 where
-  lifecycle_state = 'ACTIVE';
+  lifecycle_state <> 'ACTIVE';
 ```

--- a/oci/common_columns.go
+++ b/oci/common_columns.go
@@ -12,4 +12,5 @@ const (
 	// Other repetitive columns for the provider
 	ColumnDescriptionFreefromTags = "Free-form tags for resource. This tags can be applied by any user with permissions on the resource."
 	ColumnDescriptionDefinedTags  = "Defined tags for resource. Defined tags are set up in your tenancy by an administrator. Only users granted permission to work with the defined tags can apply them to resources."
+	ColumnDescriptionSystemTags   = "System tags for resource. System tags can be viewed by users, but can only be created by the system."
 )

--- a/oci/table_oci_cloud_guard_detector_recipe.go
+++ b/oci/table_oci_cloud_guard_detector_recipe.go
@@ -192,7 +192,7 @@ func getCloudGuardDetectorRecipe(ctx context.Context, d *plugin.QueryData, h *pl
 	if h.Item != nil {
 		id = *h.Item.(cloudguard.DetectorRecipeSummary).Id
 	} else {
-		// Rstrict the api call to only root compartment
+		// Restrict the api call to only root compartment
 		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
 			return nil, nil
 		}

--- a/oci/table_oci_cloud_guard_detector_recipe.go
+++ b/oci/table_oci_cloud_guard_detector_recipe.go
@@ -188,14 +188,14 @@ func getCloudGuardDetectorRecipe(ctx context.Context, d *plugin.QueryData, h *pl
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.getCloudGuardDetectorRecipe", "Compartment", compartment)
 
-	// Rstrict the api call to only root compartment
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
-		return nil, nil
-	}
 	var id string
 	if h.Item != nil {
 		id = *h.Item.(cloudguard.DetectorRecipeSummary).Id
 	} else {
+		// Rstrict the api call to only root compartment
+		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+			return nil, nil
+		}
 		id = d.KeyColumnQuals["id"].GetStringValue()
 	}
 

--- a/oci/table_oci_cloud_guard_detector_recipe.go
+++ b/oci/table_oci_cloud_guard_detector_recipe.go
@@ -106,7 +106,7 @@ func tableCloudGuardDetectorRecipe(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "system_tags",
-				Description: "Tags added to instances by the service.",
+				Description: ColumnDescriptionSystemTags,
 				Type:        proto.ColumnType_JSON,
 			},
 

--- a/oci/table_oci_cloud_guard_managed_list.go
+++ b/oci/table_oci_cloud_guard_managed_list.go
@@ -110,7 +110,7 @@ func tableCloudGuardManagedList(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "system_tags",
-				Description: "Tags added to instances by the service.",
+				Description: ColumnDescriptionSystemTags,
 				Type:        proto.ColumnType_JSON,
 			},
 

--- a/oci/table_oci_cloud_guard_responder_recipe.go
+++ b/oci/table_oci_cloud_guard_responder_recipe.go
@@ -106,7 +106,7 @@ func tableCloudGuardResponderRecipe(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "system_tags",
-				Description: "Tags added to instances by the service.",
+				Description: ColumnDescriptionSystemTags,
 				Type:        proto.ColumnType_JSON,
 			},
 

--- a/oci/table_oci_cloud_guard_responder_recipe.go
+++ b/oci/table_oci_cloud_guard_responder_recipe.go
@@ -192,7 +192,7 @@ func getCloudGuardResponderRecipe(ctx context.Context, d *plugin.QueryData, h *p
 	if h.Item != nil {
 		id = *h.Item.(cloudguard.ResponderRecipeSummary).Id
 	} else {
-		// Rstrict the api call to only root compartment/ per region
+		// Restrict the api call to only root compartment/ per region
 		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
 			return nil, nil
 		}

--- a/oci/table_oci_cloud_guard_responder_recipe.go
+++ b/oci/table_oci_cloud_guard_responder_recipe.go
@@ -188,14 +188,14 @@ func getCloudGuardResponderRecipe(ctx context.Context, d *plugin.QueryData, h *p
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.getCloudGuardResponderRecipe", "Compartment", compartment)
 
-	// Rstrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
-		return nil, nil
-	}
 	var id string
 	if h.Item != nil {
 		id = *h.Item.(cloudguard.ResponderRecipeSummary).Id
 	} else {
+		// Rstrict the api call to only root compartment/ per region
+		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+			return nil, nil
+		}
 		id = d.KeyColumnQuals["id"].GetStringValue()
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/oci_cloud_guard_detector_recipe []

PRETEST: tests/oci_cloud_guard_detector_recipe

TEST: tests/oci_cloud_guard_detector_recipe
Running terraform
oci_cloud_guard_detector_recipe.named_test_resource: Creating...
oci_cloud_guard_detector_recipe.named_test_resource: Creation complete after 2s [id=ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaauolphxgsujftpaqikzephakqwulwymlll5zqxn5gpgaa]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaauolphxgsujftpaqikzephakqwulwymlll5zqxn5gpgaa"
resource_name = "steampipetest804"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaauolphxgsujftpaqikzephakqwulwymlll5zqxn5gpgaa",
    "lifecycle_state": "ACTIVE",
    "name": "steampipetest804"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaauolphxgsujftpaqikzephakqwulwymlll5zqxn5gpgaa",
    "lifecycle_state": "ACTIVE",
    "name": "steampipetest804"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest804"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_detector_recipe

TEARDOWN: tests/oci_cloud_guard_detector_recipe

SUMMARY:

1/1 passed.


SETUP: tests/oci_cloud_guard_responder_recipe []

PRETEST: tests/oci_cloud_guard_responder_recipe

TEST: tests/oci_cloud_guard_responder_recipe
Running terraform
oci_cloud_guard_responder_recipe.named_test_resource: Creating...
oci_cloud_guard_responder_recipe.named_test_resource: Creation complete after 1s [id=ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaavajrnj7bqibflf4i5cucahlyhs3is6cfdixaua2c3fa]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaavajrnj7bqibflf4i5cucahlyhs3is6cfdixaua2c3fa"
resource_name = "steampipetest2813"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaavajrnj7bqibflf4i5cucahlyhs3is6cfdixaua2c3fa",
    "lifecycle_state": "ACTIVE",
    "name": "steampipetest2813"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaavajrnj7bqibflf4i5cucahlyhs3is6cfdixaua2c3fa",
    "lifecycle_state": "ACTIVE",
    "name": "steampipetest2813"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest2813"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_responder_recipe

TEARDOWN: tests/oci_cloud_guard_responder_recipe

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  time_created,
  lifecycle_state as state
from
  oci_cloud_guard_detector_recipe;
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
| name                              | id                                                                                                          | time_created        | state  |
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
| test1                             | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaw2j2d7kwdl367wh55eghnrgsneh6kx36qvjcjr53uhna | 2021-04-22 10:39:23 | ACTIVE |
| OCI Activity Detector Recipe      | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexcqvh5ediqen7fynutocg2eicmsfzqlz2eaautgkuszzrwq | 2021-04-16 07:05:12 | ACTIVE |
| test2                             | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaz5rpyy4xofainly2z2dkotbmyp54sg52y7ajao3th7tq | 2021-04-22 10:57:58 | ACTIVE |
| cis-test                          | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaad6elnqy3fktnflcq5befe7k2pgcr6c47r4jp543nclyq | 2021-04-22 10:20:08 | ACTIVE |
| OCI Configuration Detector Recipe | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexcqi6cyqmqqtixpebhvtxayoxeppex6ox5x4k6j4pdbtjsa | 2021-04-16 07:05:12 | ACTIVE |
| test-45                           | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaatr5zisacw742a2q3ujb5kh3atl3bw5mf3zflovsbihma | 2021-04-19 12:56:05 | ACTIVE |
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
> select
  name,
  id,
  time_created,
  lifecycle_state as state
from
  oci_cloud_guard_detector_recipe
where
  lifecycle_state = 'ACTIVE';
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
| name                              | id                                                                                                          | time_created        | state  |
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
| test-45                           | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaatr5zisacw742a2q3ujb5kh3atl3bw5mf3zflovsbihma | 2021-04-19 12:56:05 | ACTIVE |
| OCI Activity Detector Recipe      | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexcqvh5ediqen7fynutocg2eicmsfzqlz2eaautgkuszzrwq | 2021-04-16 07:05:12 | ACTIVE |
| OCI Configuration Detector Recipe | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexcqi6cyqmqqtixpebhvtxayoxeppex6ox5x4k6j4pdbtjsa | 2021-04-16 07:05:12 | ACTIVE |
| cis-test                          | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaad6elnqy3fktnflcq5befe7k2pgcr6c47r4jp543nclyq | 2021-04-22 10:20:08 | ACTIVE |
| test2                             | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaz5rpyy4xofainly2z2dkotbmyp54sg52y7ajao3th7tq | 2021-04-22 10:57:58 | ACTIVE |
| test1                             | ocid1.cloudguarddetectorrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaw2j2d7kwdl367wh55eghnrgsneh6kx36qvjcjr53uhna | 2021-04-22 10:39:23 | ACTIVE |
+-----------------------------------+-------------------------------------------------------------------------------------------------------------+---------------------+--------+
> select
  name,
  id,
  time_created,
  lifecycle_state as state
from
  oci_cloud_guard_responder_recipe;
+----------------------+--------------------------------------------------------------------------------------------------------------+---------------------+--------+
| name                 | id                                                                                                           | time_created        | state  |
+----------------------+--------------------------------------------------------------------------------------------------------------+---------------------+--------+
| test34               | ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaatyt3sflsv6q2xmbm4w64gdj5qm7437lm7umes3v6jvwa | 2021-04-17 19:19:58 | ACTIVE |
| OCI Responder Recipe | ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexcqowkncgjhc2sgk7qlacbd6etrvm4euamxe3f3xesnzunq | 2021-04-16 07:05:12 | ACTIVE |
| terert               | ocid1.cloudguardresponderrecipe.oc1.ap-mumbai-1.amaaaaaa6igdexaaerv6mbzcnoyycosapd3e5x3d4hgldtic7oqsg472bsoa | 2021-05-26 07:25:41 | ACTIVE |
+----------------------+--------------------------------------------------------------------------------------------------------------+---------------------+--------+
> select
  name,
  id,
  time_created,
  lifecycle_state as state
from
  oci_cloud_guard_managed_list
where
  lifecycle_state <> 'ACTIVE';
+------+----+--------------+-------+
| name | id | time_created | state |
+------+----+--------------+-------+
+------+----+--------------+-------+
> select
  name,
  id,
  time_created,
  lifecycle_state as state
from
  oci_cloud_guard_responder_recipe
where
  lifecycle_state <> 'ACTIVE';
+------+----+--------------+-------+
| name | id | time_created | state |
+------+----+--------------+-------+
+------+----+--------------+-------+

```
</details>
