### PR TITLE
Updated  oci_kms_key_version doc example query.Closes #153

### DIFF
--- a/docs/tables/oci_kms_key_version.md
+++ b/docs/tables/oci_kms_key_version.md
@@ -23,19 +23,24 @@ where
   and v.region = k.region;
 ```
 
-### Get latest key version for all keys
+### Get latest key version for all active keys
 
 ```sql
 select
   k.name as key_name,
-  max(v.time_created) as latest_key_version_created
+  k.lifecycle_state,
+  max(v.time_created) as latest_key_version_created,
+  k.region,
+  coalesce(c.name, 'root') as compartment
 from
-  oci_kms_key k,
+  oci_kms_key k
+  left join oci_identity_compartment c on c.id = k.compartment_id,
   oci_kms_key_version v
 where
   v.key_id = k.id
   and v.management_endpoint = k.management_endpoint
   and v.region = k.region
+  and k.lifecycle_state = 'ENABLED'
 group by
-  key_name;
+  key_name, k.lifecycle_state, k.region, compartment
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
```
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  k.name as key_name,
  k.lifecycle_state,
  k.region,
  max(v.time_created) as latest_key_version_created
from
  oci_kms_key k,
  oci_kms_key_version v
where
  v.key_id = k.id
  and v.management_endpoint = k.management_endpoint
  and v.region = k.region
  and k.lifecycle_state = 'ENABLED'
group by
  key_name, k.lifecycle_state, k.region
+------------------------------------+-----------------+--------------+----------------------------+
| key_name                           | lifecycle_state | region       | latest_key_version_created |
+------------------------------------+-----------------+--------------+----------------------------+
| software-cmk-raj                   | ENABLED         | ap-mumbai-1  | 2021-06-28 15:58:30        |
| test-sw-jun28                      | ENABLED         | ap-mumbai-1  | 2021-06-28 16:19:47        |
| test_cmk                           | ENABLED         | us-ashburn-1 | 2021-06-17 10:16:06        |
| test_rajesh                        | ENABLED         | ap-mumbai-1  | 2021-06-28 16:21:43        |
| testsw                             | ENABLED         | ap-mumbai-1  | 2021-06-28 16:10:30        |
| turbot-test-20200125-create-update | ENABLED         | ap-mumbai-1  | 2021-06-22 14:09:31        |
| vishal-key                         | ENABLED         | us-ashburn-1 | 2021-06-22 15:23:41        |
| wewrt                              | ENABLED         | ap-mumbai-1  | 2021-06-23 03:05:05        |
+------------------------------------+-----------------+--------------+----------------------------+
```
</details>
