### PR TITLE
Remove region column from oci_dns_zone. Closes #156

### DIFF
--- a/oci/table_oci_dns_zone.go
+++ b/oci/table_oci_dns_zone.go
@@ -130,12 +130,6 @@ func tableDnsZone(_ context.Context) *plugin.Table {
 
 			// Standard OCI columns
 			{
-				Name:        "region",
-				Description: ColumnDescriptionRegion,
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Self").Transform(ociRegionFromSelf),
-			},
-			{
 				Name:        "compartment_id",
 				Description: ColumnDescriptionCompartment,
 				Type:        proto.ColumnType_STRING,
@@ -199,7 +193,7 @@ func getDnsZone(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.getDnsZone", "Compartment", compartment)
 
-	// Rstrict the api call to only root compartment/ per region
+	// Rstrict the api call to only root compartment
 	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
 		return nil, nil
 	}
@@ -276,8 +270,4 @@ func dnsZoneTags(_ context.Context, d *transform.TransformData) (interface{}, er
 	}
 
 	return tags, nil
-}
-
-func ociRegionFromSelf(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	return oci_common.StringToRegion(strings.Split(types.SafeString(d.Value), ".")[1]), nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,id,lifecycle_state,self from oci_dns_zone
+------------+------------------------------------------------------+-----------------+--------------------------------------------------------------------+
| name       | id                                                   | lifecycle_state | self                                                               |
+------------+------------------------------------------------------+-----------------+--------------------------------------------------------------------+
| testqw.com | ocid1.dns-zone.oc1..21bbfca7cd0f48dea250a44f3282d7cf | ACTIVE          | https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/testqw.com |
| turbot.com | ocid1.dns-zone.oc1..7ad8a63053bc467486483f39a0232889 | ACTIVE          | https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/turbot.com |
| terte.com  | ocid1.dns-zone.oc1..f55fad5b4f684c75a1e5030a7356c3a5 | ACTIVE          | https://dns.us-ashburn-1.oraclecloud.com/20180115/zones/terte.com  |
+------------+------------------------------------------------------+-----------------+--------------------------------------------------------------------+

```
</details>
