### PR TITLE
remove region column from oci_dns_tsig_key. Closes#158

### DIFF
--- a/oci/table_oci_dns_tsig_key.go
+++ b/oci/table_oci_dns_tsig_key.go
@@ -103,12 +103,6 @@ func tableDnsTsigKey(_ context.Context) *plugin.Table {
 
 			// Standard OCI columns
 			{
-				Name:        "region",
-				Description: ColumnDescriptionRegion,
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Self").Transform(ociRegionFromSelf),
-			},
-			{
 				Name:        "compartment_id",
 				Description: ColumnDescriptionCompartment,
 				Type:        proto.ColumnType_STRING,
@@ -172,7 +166,7 @@ func getDnsTsigKey(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.getDnsTsigKey", "Compartment", compartment)
 
-	// Rstrict the api call to only root compartment/ per region
+	// Rstrict the api call to only root compartment
 	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
 		return nil, nil
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,id,lifecycle_state,self from oci_dns_tsig_key
+-----------+----------------------------------------------------------+-----------------+------------------------------------------------------------------------------------------------------------------
| name      | id                                                       | lifecycle_state | self                                                                                                             
+-----------+----------------------------------------------------------+-----------------+------------------------------------------------------------------------------------------------------------------
| test-tsig | ocid1.dns-tsig-key.oc1..24fded1c08ff4f50863d9a3047c569ae | ACTIVE          | https://dns.us-ashburn-1.oraclecloud.com/20180115/tsigs/ocid1.dns-tsig-key.oc1..24fded1c08ff4f50863d9a3047c569ae 
+-----------+----------------------------------------------------------+-----------------+------------------------------------------------------------------------------------------------------------------
```
</details>
