### PR TITLE
Add column object_lifecycle_policy in the table oci_objectstorage_bucket. Closes #186

### DIFF
--- a/docs/tables/oci_objectstorage_bucket.md
+++ b/docs/tables/oci_objectstorage_bucket.md
@@ -76,3 +76,17 @@ from
 where
   not replication_enabled;
 ```
+
+### List buckets without lifecycle
+
+```sql
+select
+  name,
+  id,
+  object_lifecycle_policy -> 'items' as object_lifecycle_policy_rules
+from
+  oci_objectstorage_bucket
+where
+  object_lifecycle_policy ->> 'items' is null
+  or jsonb_array_length(object_lifecycle_policy -> 'items') = 0;
+```

--- a/oci-test/tests/oci_objectstorage_bucket/test-hydrate-expected.json
+++ b/oci-test/tests/oci_objectstorage_bucket/test-hydrate-expected.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "{{ resourceName }}",
+    "object_lifecycle_policy_rules": [
+      {
+        "action": "ARCHIVE",
+        "isEnabled": true,
+        "name": "{{ resourceName }}",
+        "objectNameFilter": null,
+        "target": "objects",
+        "timeAmount": 30,
+        "timeUnit": "DAYS"
+      }
+    ]
+  }
+]

--- a/oci-test/tests/oci_objectstorage_bucket/test-hydrate-query.sql
+++ b/oci-test/tests/oci_objectstorage_bucket/test-hydrate-query.sql
@@ -1,0 +1,7 @@
+select
+  name,
+  object_lifecycle_policy -> 'items' as object_lifecycle_policy_rules
+from
+  oci.oci_objectstorage_bucket
+where
+  name = '{{ resourceName }}';

--- a/oci-test/tests/oci_objectstorage_bucket/variables.tf
+++ b/oci-test/tests/oci_objectstorage_bucket/variables.tf
@@ -38,6 +38,22 @@ resource "oci_objectstorage_bucket" "named_test_resource" {
   freeform_tags = {"Department"= "Finance"}
 }
 
+resource "oci_objectstorage_object_lifecycle_policy" "test_object_lifecycle_policy" {
+  depends_on = [oci_objectstorage_bucket.named_test_resource]
+  bucket = var.resource_name
+  namespace = data.oci_objectstorage_namespace.test_namespace.namespace
+
+  # Rules
+  rules {
+    action = "ARCHIVE"
+    is_enabled = true
+    name = var.resource_name
+    time_amount = 30
+    time_unit = "DAYS"
+    target = "objects"
+  }
+}
+
 output "resource_name" {
   value = var.resource_name
 }

--- a/oci/table_oci_objectstorage_bucket.go
+++ b/oci/table_oci_objectstorage_bucket.go
@@ -136,7 +136,7 @@ func tableObjectStorageBucket(_ context.Context) *plugin.Table {
 				Name:        "object_lifecycle_policy",
 				Description: "Specifies the object lifecycle policy for the bucket.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getObjectStorageObjectLifecycle,
+				Hydrate:     getObjectStorageBucketObjectLifecycle,
 				Transform:   transform.FromValue(),
 			},
 
@@ -299,8 +299,8 @@ func getObjectStorageBucket(ctx context.Context, d *plugin.QueryData, h *plugin.
 	return response.Bucket, nil
 }
 
-func getObjectStorageObjectLifecycle(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getObjectStorageObjectLifecycle")
+func getObjectStorageBucketObjectLifecycle(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getObjectStorageBucketObjectLifecycle")
 
 	data := h.Item.(bucketInfo)
 	bucketName := data.Name

--- a/oci/table_oci_objectstorage_bucket.go
+++ b/oci/table_oci_objectstorage_bucket.go
@@ -2,10 +2,12 @@ package oci
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	oci_common "github.com/oracle/oci-go-sdk/v36/common"
 	"github.com/oracle/oci-go-sdk/v36/objectstorage"
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -129,6 +131,13 @@ func tableObjectStorageBucket(_ context.Context) *plugin.Table {
 				Description: "Arbitrary string keys and values for user-defined metadata.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getObjectStorageBucket,
+			},
+			{
+				Name:        "object_lifecycle_policy",
+				Description: "Specifies the object lifecycle policy for the bucket.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getObjectStorageObjectLifecycle,
+				Transform:   transform.FromValue(),
 			},
 
 			// tags
@@ -288,6 +297,38 @@ func getObjectStorageBucket(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	return response.Bucket, nil
+}
+
+func getObjectStorageObjectLifecycle(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getObjectStorageObjectLifecycle")
+
+	data := h.Item.(bucketInfo)
+	bucketName := data.Name
+	nameSpace := data.Namespace
+
+	// Create Session
+	session, err := objectStorageService(ctx, d, data.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	request := objectstorage.GetObjectLifecyclePolicyRequest{
+		NamespaceName: nameSpace,
+		BucketName:    bucketName,
+		RequestMetadata: oci_common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+	response, err := session.ObjectStorageClient.GetObjectLifecyclePolicy(ctx, request)
+	if err != nil {
+		if ociErr, ok := err.(oci_common.ServiceError); ok {
+			if helpers.StringSliceContains([]string{"LifecyclePolicyNotFound"}, strconv.Itoa(ociErr.GetHTTPStatusCode())) {
+				return nil, nil
+			}
+		}
+	}
+
+	return response.ObjectLifecyclePolicy, nil
 }
 
 //// TRANSFORM FUNCTION


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_objectstorage_bucket' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
Custom env variable TURBOT_TEST_EXPECTED_TIMEOUT=300

SETUP: tests/oci_objectstorage_bucket []

PRETEST: tests/oci_objectstorage_bucket

TEST: tests/oci_objectstorage_bucket
Running terraform
data.oci_objectstorage_namespace.test_namespace: Refreshing state...
oci_objectstorage_bucket.named_test_resource: Creating...
oci_objectstorage_bucket.named_test_resource: Creation complete after 0s [id=n/bmqeqvslavsz/b/steampipetest5489]
oci_objectstorage_object_lifecycle_policy.test_object_lifecycle_policy: Creating...
oci_objectstorage_object_lifecycle_policy.test_object_lifecycle_policy: Creation complete after 3s [id=n/bmqeqvslavsz/b/steampipetest5489/l]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

freeform_tags = {
  "Department" = "Finance"
}
namespace = bmqeqvslavsz
resource_id = ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaa4j2bo67ou6a374mmxa5p4cgxxwqjawcsbvsurd2kmg4gejomeenq
resource_name = steampipetest5489
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3ohz4p42qh37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "freeform_tags": {
      "Department": "Finance"
    },
    "id": "ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaa4j2bo67ou6a374mmxa5p4cgxxwqjawcsbvsurd2kmg4gejomeenq",
    "name": "steampipetest5489",
    "namespace": "bmqeqvslavsz",
    "versioning": "Disabled"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

[
  {
    "name": "steampipetest5489",
    "object_lifecycle_policy_rules": [
      {
        "action": "ARCHIVE",
        "isEnabled": true,
        "name": "steampipetest5489",
        "objectNameFilter": null,
        "target": "objects",
        "timeAmount": 30,
        "timeUnit": "DAYS"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "freeform_tags": {
      "Department": "Finance"
    },
    "id": "ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaa4j2bo67ou6a374mmxa5p4cgxxwqjawcsbvsurd2kmg4gejomeenq",
    "name": "steampipetest5489",
    "namespace": "bmqeqvslavsz",
    "versioning": "Disabled"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3ohz4p42qh37cyljaq",
    "title": "steampipetest5489"
  }
]
✔ PASSED

POSTTEST: tests/oci_objectstorage_bucket

TEARDOWN: tests/oci_objectstorage_bucket

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

### List buckets without lifecycle

```sql
select
  name,
  id,
  object_lifecycle_policy -> 'items' as object_lifecycle_policy_rules
from
  oci_objectstorage_bucket
where
  object_lifecycle_policy ->> 'items' is null
  or jsonb_array_length(object_lifecycle_policy -> 'items') = 0;
```
```
+-------------------------------------------------------------------------------------------+----------------------------+-------------------------------+
| id                                                                                        | name                       | object_lifecycle_policy_rules |
+-------------------------------------------------------------------------------------------+----------------------------+-------------------------------+
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaakmxbt4plr7wi6jedylq44pvt4viip3usmdtcctxu5m7oshh2pn7q | bucket-20210623-1245       | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaail27kl6b3gqtgha6yp7toszokihqs2oplwxcycwplyd4qi7mrx2a | bucket-20210712-1914-debu  | []                            |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaafa75mylwdfyojirrqpb47ycj7e6qvlg25thibl2ridcefzkygnaa | raj-bucket-20210623-1241   | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaa2ajy66gdlgwspr3sgwiwrjyrbknok32rhlq5vb3nwnud6mepgxua | bucket-20210623-1827-new10 | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaan5ndpwyyjti4dpm5j5ztaxhjtkxm7fsxaapyav6r32r2o47ok4hq | raj-bucket-20210623-1242   | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaa4p6xxvu6u3kqjvzfr5nflyne2t36edrf5oybysjvepvqydxyv72a | bucket-20210623-1453-new   | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaanbqtwabzhttfpo4inm7sxqljzl7ja5akymvyslbq7cwqsih6oh6a | bucket-20210623-1744-kk    | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaavx5bgwnrhqczpez7i2r45kwgqueojifb34gbwqpnh22al4drvita | bucket-20210623-1742-k     | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaaufbc6xdvqe3sy5bghpobd7fnshessbm5c5xk7xdr2w6doz2qfw4q | bucket-20210623-1534-new1  | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaacym4pzy44bsk2qjqceu3dh5gfv72do3ppbbs6jdjvglyfkm2avlq | bucket-20210308-1928       | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaao4tgdbee7n6bqgabxvmen2twm3otgbmnqvwfkqwn6ers7l7gmula | steampipetest4434          | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaaou7uda4wylzuaoyypgm5hzvzjiz2pmcepcxataxt5fq2gyrqka6a | bucket-20210308-1927       | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaaqrtx64oeo2fgxa53yzy6eu4lja3hytn26bkswagm57mokfzh5bra | cis-test-bucket            | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaayhzxcapqd7lksa5taeaqydcnvxadpwscvau4o4bpyqpyvrjpqlma | bucket-20210623-1307-new   | <null>                        |
| ocid1.bucket.oc1.ap-mumbai-1.aaaaaaaawtiett3g3pasiieykcourwgg4krgfqq5rrzfbclrtawlpajm4wua | bucket-20210623-1202       | <null>                        |
| ocid1.bucket.oc1.iad.aaaaaaaactv5w3hgor46ncuia4l3gc42y6lflwdbwwpkcclxx6mtcefm76va         | testinh-new-region         | <null>                        |
| ocid1.bucket.oc1.iad.aaaaaaaa2gxladaojkspvoqia6effponzgpggnczb464jmt5pofsqtl7or6q         | test90                     | <null>                        |
+-------------------------------------------------------------------------------------------+----------------------------+-------------------------------+
```
</details>
