### PR TITLE
Fix error: undeclared tenantID when defining service connection for networkLoadBalancerService. Closes #231

### DIFF
--- a/oci/service.go
+++ b/oci/service.go
@@ -1058,12 +1058,21 @@ func networkLoadBalancerService(ctx context.Context, d *plugin.QueryData, region
 		return nil, err
 	}
 
-	client, err := networkloadbalancer.NewNetworkLoadBalancerClientWithConfigurationProvider(provider) 
+	client, err := networkloadbalancer.NewNetworkLoadBalancerClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	tenantID, err := provider.TenancyOCID()
+	if err != nil {
+		return nil, err
+	}
+
 	sess := &session{
 		TenancyID:                 tenantID,
 		NetworkLoadBalancerClient: client,
 	}
-  
+
 	// save session in cache
 	d.ConnectionManager.Cache.Set(serviceCacheKey, sess)
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
