### PR TITLE
Add Column region for metric tables. Closes #239

### DIFF
--- a/oci/monitoring_metric.go
+++ b/oci/monitoring_metric.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/oracle/oci-go-sdk/v44/common"
+	oci_common "github.com/oracle/oci-go-sdk/v44/common"
 	"github.com/oracle/oci-go-sdk/v44/monitoring"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -162,7 +163,7 @@ type MetricData struct {
 	Timestamp     *time.Time
 }
 
-func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, granularity string, namespace string, metricName string, dimensionName string, dimensionValue string, compartmentId string) (*monitoring.SummarizeMetricsDataResponse, error) {
+func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, granularity string, namespace string, metricName string, dimensionName string, dimensionValue string, compartmentId string, TableId string) (*monitoring.SummarizeMetricsDataResponse, error) {
 	plugin.Logger(ctx).Trace("listMonitoringMetricStatistics")
 	// Create Session
 	session, err := monitoringService(ctx, d)
@@ -182,6 +183,10 @@ func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, gr
 	querystringSum := queryString + ".grouping().sum()"
 	querystringCount := queryString + ".grouping().count()"
 
+	if TableId != "" {
+		dimensionValue = TableId
+	}
+
 	// Set Inteval
 	interval := getMonitoringPeriodForGranularity(granularity)
 	metricDetails := monitoring.SummarizeMetricsDataDetails{
@@ -195,6 +200,9 @@ func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, gr
 	requestParam := monitoring.SummarizeMetricsDataRequest{
 		CompartmentId:               &compartmentId,
 		SummarizeMetricsDataDetails: metricDetails,
+		RequestMetadata: oci_common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
 	}
 
 	// Mean statistics

--- a/oci/monitoring_metric.go
+++ b/oci/monitoring_metric.go
@@ -183,8 +183,11 @@ func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, gr
 	querystringSum := queryString + ".grouping().sum()"
 	querystringCount := queryString + ".grouping().count()"
 
+	var resourceId string
 	if TableId != "" {
-		dimensionValue = TableId
+		resourceId = TableId
+	} else {
+		resourceId = dimensionValue
 	}
 
 	// Set Inteval
@@ -251,7 +254,7 @@ func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, gr
 		for _, datapoint := range item.AggregatedDatapoints {
 			d.StreamLeafListItem(ctx, &MonitoringMetricRow{
 				CompartmentId:  item.CompartmentId,
-				DimensionValue: &dimensionValue,
+				DimensionValue: &resourceId,
 				DimensionName:  &dimensionName,
 				Namespace:      &namespace,
 				MetricName:     &metricName,

--- a/oci/monitoring_metric.go
+++ b/oci/monitoring_metric.go
@@ -20,12 +20,6 @@ func MonitoringMetricColumns(columns []*plugin.Column) []*plugin.Column {
 func commonMonitoringMetricColumns() []*plugin.Column {
 	return []*plugin.Column{
 		{
-			Name:        "compartment_id",
-			Description: "The ID of the compartment.",
-			Type:        proto.ColumnType_STRING,
-			Transform:   transform.FromField("CompartmentId"),
-		},
-		{
 			Name:        "metric_name",
 			Description: "The name of the metric.",
 			Type:        proto.ColumnType_STRING,
@@ -70,6 +64,25 @@ func commonMonitoringMetricColumns() []*plugin.Column {
 			Name:        "timestamp",
 			Description: "The time stamp used for the data point.",
 			Type:        proto.ColumnType_TIMESTAMP,
+		},
+		{
+			Name:        "region",
+			Description: ColumnDescriptionRegion,
+			Type:        proto.ColumnType_STRING,
+			Transform:   transform.FromField("DimensionValue").Transform(ociRegionName),
+		},
+		{
+			Name:        "compartment_id",
+			Description: "The ID of the compartment.",
+			Type:        proto.ColumnType_STRING,
+			Transform:   transform.FromField("CompartmentId"),
+		},
+		{
+			Name:        "tenant_id",
+			Description: ColumnDescriptionTenant,
+			Type:        proto.ColumnType_STRING,
+			Hydrate:     getTenantId,
+			Transform:   transform.FromValue(),
 		},
 	}
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricReadOps(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricReadOps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricReadOps(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricReadOps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops_daily.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops_daily.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricReadOpsDaily(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricReadOpsDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops_daily.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricReadOpsDaily(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricReadOpsDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops_hourly.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricReadOpsHourly(_ context.Context) *plugin.Table 
 func listCoreBootVolumeMetricReadOpsHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_boot_volume_metric_read_ops_hourly.go
+++ b/oci/table_oci_core_boot_volume_metric_read_ops_hourly.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricReadOpsHourly(_ context.Context) *plugin.Table 
 func listCoreBootVolumeMetricReadOpsHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeReadOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricWriteOps(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricWriteOps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricWriteOps(_ context.Context) *plugin.Table {
 func listCoreBootVolumeMetricWriteOps(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops_daily.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricWriteOpsDaily(_ context.Context) *plugin.Table 
 func listCoreBootVolumeMetricWriteOpsDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops_daily.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops_daily.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricWriteOpsDaily(_ context.Context) *plugin.Table 
 func listCoreBootVolumeMetricWriteOpsDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops_hourly.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops_hourly.go
@@ -34,5 +34,5 @@ func tableOciCoreBootVolumeMetricWriteOpsHourly(_ context.Context) *plugin.Table
 func listCoreBootVolumeMetricWriteOpsHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
 }

--- a/oci/table_oci_core_boot_volume_metric_write_ops_hourly.go
+++ b/oci/table_oci_core_boot_volume_metric_write_ops_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -34,5 +35,6 @@ func tableOciCoreBootVolumeMetricWriteOpsHourly(_ context.Context) *plugin.Table
 func listCoreBootVolumeMetricWriteOpsHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// We can get the metric details of volume, only which are attach with the instance or boot volume
 	volume := h.Item.(core.BootVolume)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*volume.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_blockstore", "VolumeWriteOps", "resourceId", *volume.Id, *volume.CompartmentId, region)
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -33,5 +34,6 @@ func tableOciCoreInstanceMetricCpuUtilization(_ context.Context) *plugin.Table {
 
 func listCoreInstanceMetricCpuUtilization(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*instance.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, region)
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization.go
@@ -33,5 +33,5 @@ func tableOciCoreInstanceMetricCpuUtilization(_ context.Context) *plugin.Table {
 
 func listCoreInstanceMetricCpuUtilization(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization_daily.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization_daily.go
@@ -33,5 +33,5 @@ func tableOciCoreInstanceMetricCpuUtilizationDaily(_ context.Context) *plugin.Ta
 
 func listCoreInstanceMetricCpuUtilizationDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization_daily.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -33,5 +34,6 @@ func tableOciCoreInstanceMetricCpuUtilizationDaily(_ context.Context) *plugin.Ta
 
 func listCoreInstanceMetricCpuUtilizationDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*instance.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, region)
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization_hourly.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization_hourly.go
@@ -33,5 +33,5 @@ func tableOciCoreInstanceMetricCpuUtilizationHourly(_ context.Context) *plugin.T
 
 func listCoreInstanceMetricCpuUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
 }

--- a/oci/table_oci_core_instance_metric_cpu_utilization_hourly.go
+++ b/oci/table_oci_core_instance_metric_cpu_utilization_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/core"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -33,5 +34,6 @@ func tableOciCoreInstanceMetricCpuUtilizationHourly(_ context.Context) *plugin.T
 
 func listCoreInstanceMetricCpuUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(core.Instance)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, "")
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*instance.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_computeagent", "CpuUtilization", "resourceId", *instance.Id, *instance.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricReadThrottleCount(_ context.Context) *plugin.Table 
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricReadThrottleCount(_ context.Context) *plugin.Table 
 
 func listNoSQLTableMetricReadThrottleCount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count.go
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricReadThrottleCount(_ context.Context) *plugin.Table 
 
 func listNoSQLTableMetricReadThrottleCount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricReadThrottleCount(_ context.Context) *plugin.Table 
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricReadThrottleCount(_ context.Context) *plugin.Table 
 
 func listNoSQLTableMetricReadThrottleCount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count_daily.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricReadThrottleCountDaily(_ context.Context) *plugin.T
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricReadThrottleCountDaily(_ context.Context) *plugin.T
 
 func listNoSQLTableMetricReadThrottleCountDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count_daily.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count_daily.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricReadThrottleCountDaily(_ context.Context) *plugin.T
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricReadThrottleCountDaily(_ context.Context) *plugin.T
 
 func listNoSQLTableMetricReadThrottleCountDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count_hourly.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricReadThrottleCountHourly(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricReadThrottleCountHourly(_ context.Context) *plugin.
 
 func listNoSQLTableMetricReadThrottleCountHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_read_throttle_count_hourly.go
+++ b/oci/table_oci_nosql_table_metric_read_throttle_count_hourly.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricReadThrottleCountHourly(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricReadThrottleCountHourly(_ context.Context) *plugin.
 
 func listNoSQLTableMetricReadThrottleCountHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "ReadThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricStorageUtilization(_ context.Context) *plugin.Table
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricStorageUtilization(_ context.Context) *plugin.Table
 
 func listNoSQLTableMetricStorageUtilization(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricStorageUtilization(_ context.Context) *plugin.Table
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricStorageUtilization(_ context.Context) *plugin.Table
 
 func listNoSQLTableMetricStorageUtilization(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricStorageUtilizationDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricStorageUtilizationDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId,*table.Id)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricStorageUtilizationDaily(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricStorageUtilizationDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricStorageUtilizationDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId,*table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricStorageUtilizationDaily(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricStorageUtilizationDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricStorageUtilizationDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricStorageUtilizationHourly(_ context.Context) *plugin
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricStorageUtilizationHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricStorageUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId,*table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricStorageUtilizationHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricStorageUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId,*table.Id)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
+++ b/oci/table_oci_nosql_table_metric_storage_utilization_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricStorageUtilizationHourly(_ context.Context) *plugin
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricStorageUtilizationHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricStorageUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "StorageGB", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricWriteThrottleCount(_ context.Context) *plugin.Table
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricWriteThrottleCount(_ context.Context) *plugin.Table
 
 func listNoSQLTableMetricWriteThrottleCount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricWriteThrottleCount(_ context.Context) *plugin.Table
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricWriteThrottleCount(_ context.Context) *plugin.Table
 
 func listNoSQLTableMetricWriteThrottleCount(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "5_MIN", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricWriteThrottleCountDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricWriteThrottleCountDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricWriteThrottleCountDaily(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricWriteThrottleCountDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricWriteThrottleCountDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_daily.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricWriteThrottleCountDaily(_ context.Context) *plugin.
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricWriteThrottleCountDaily(_ context.Context) *plugin.
 
 func listNoSQLTableMetricWriteThrottleCountDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "DAILY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricWriteThrottleCountHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricWriteThrottleCountHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
@@ -22,8 +22,8 @@ func tableOciNoSQLTableMetricWriteThrottleCountHourly(_ context.Context) *plugin
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "name",
-					Description: "Immutable human-friendly table name.",
+					Name:        "id",
+					Description: "The OCID of the NoSQL Table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +33,5 @@ func tableOciNoSQLTableMetricWriteThrottleCountHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricWriteThrottleCountHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId)
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId,*table.Id)
 }

--- a/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
+++ b/oci/table_oci_nosql_table_metric_write_throttle_count_hourly.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oracle/oci-go-sdk/v44/nosql"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -22,8 +23,8 @@ func tableOciNoSQLTableMetricWriteThrottleCountHourly(_ context.Context) *plugin
 		Columns: MonitoringMetricColumns(
 			[]*plugin.Column{
 				{
-					Name:        "id",
-					Description: "The OCID of the NoSQL Table.",
+					Name:        "name",
+					Description: "The name of the NoSQL table.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("DimensionValue"),
 				},
@@ -33,5 +34,6 @@ func tableOciNoSQLTableMetricWriteThrottleCountHourly(_ context.Context) *plugin
 
 func listNoSQLTableMetricWriteThrottleCountHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	table := h.Item.(nosql.TableSummary)
-	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, *table.Id)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*table.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_nosql", "WriteThrottleCount", "tableName", *table.Name, *table.CompartmentId, region)
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> with core_instance_utilization as (
  select
    id,
    round(cast(sum(maximum)/count(maximum) as numeric), 1) as avg_max,
    count(maximum) days
  from
    oci_core_instance_metric_cpu_utilization_daily
  where
    date_part('day', now() - timestamp) <=30
  group by
    id
)
select
  i.id as resource,
  case
    when avg_max is null then 'error'
    when avg_max < 20 then 'alarm'
    when avg_max < 35 then 'info'
    else 'ok'
  end as status,
  case
    when avg_max is null then 'Metrics not available for ' || i.title || '.'
    else i.title || ' is averaging ' || avg_max || '% max utilization over the last ' || days || ' days.'
  end as reason,
  i.region,
  coalesce(c.name, 'root') as compartment
from
  oci_core_instance i
  left join core_instance_utilization as u on u.id = i.id
  left join oci_identity_compartment as c on c.id = i.compartment_id;
+------------------------------------------------------------------------------------------------+--------+---------------------------------------------------------------+----------------+----------------
| resource                                                                                       | status | reason                                                        | region         | compartment    
+------------------------------------------------------------------------------------------------+--------+---------------------------------------------------------------+----------------+----------------
| ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexacxnvmgbasveoxvg5aewufagzsqvwctf2i6dqwpjlhtvfq    | error  | Metrics not available for instance-20210722-1120.             | ap-mumbai-1    | root           
| ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexac6zdwkgs72y54buuznp7dw4qqtqh6nbhovva5qtvr7xhq    | error  | Metrics not available for oci-thrifty-mumbai-instance-by-raj. | ap-mumbai-1    | raj-jun21-kuber
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacjg22gahzfbclplo7fxsuat3p54mrjikkpmwrurbodfoa | error  | Metrics not available for instance20210721125920.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexaces5boizyadndzt2yinwtuh2p4w2edex6ye4aqh53puuq | error  | Metrics not available for instance20210721115917.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacevcpa23spseec6r7gj6rdo6ngkvsy6j3omzqqvzs5g3q | error  | Metrics not available for instance20210721115028.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexackqulx5apfi74eimyxqksqecextdcgfqe5vw7azeu5f3q | error  | Metrics not available for instance20210721083234.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexac4c6akckwwdhh2wmbgdw4gunkjjcgsyani2ojattcv4qq | error  | Metrics not available for instance20210721120356.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacqpzzo6h5oknxhlstf47gwwdhaphocpwhq65w33efcdxa | error  | Metrics not available for instance20210721083344.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacz2nx5c7dk4m3gwx4vyjnnojj6nn5slrqdajwfutbs45q | error  | Metrics not available for instance20210721123155.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexac4zdemtaa3z2oeito36fomnxx5fcvxlohploti6g2y3ka | error  | Metrics not available for instance20210721114112.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexactnzt33egruxnt724zzloh4funeiurgwdegjv432o5dma | error  | Metrics not available for instance20210721114535.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacav7nvkj4oyzpivhcjl6mzggghxhanwin7cv5kygex4ea | error  | Metrics not available for instance20210721123645.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacfkrdqywvpyd575rx5kalnz34fsndh5bg4lmg2stxvoga | error  | Metrics not available for instance20210721082657.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacntdynjkdaod34w2nlc6mdtruw5d4blgxil4cwd3rrjxa | error  | Metrics not available for instance20210721082907.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexac2w7cgb3m24wgmep5olbym4yljzbrfmujizq7xx5iglqq | error  | Metrics not available for instance20210721125041.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacejazjzchb3qo5k6tz364qli4zeodqfrb24yf5sm22hha | error  | Metrics not available for instance20210721123852.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexac5k4zslba3dasmxv4altrpahzjhmcouv3zlez527gxl4a | error  | Metrics not available for instance20210721083146.             | ap-hyderabad-1 | root           
| ocid1.instance.oc1.ap-hyderabad-1.anuhsljr6igdexacjqw46q3nfstqwue5n6jwzvpt4yby5ghldbse343psxoq | error  | Metrics not available for instance20210721124354.             | ap-hyderabad-1 | root           
+------------------------------------------------------------------------------------------------+--------+---------------------------------------------------------------+----------------+----------------

```
</details>
