### PR TITLE
Metric statistic table should show data of multiple regions closes #242

### DIFF
--- a/oci/monitoring_metric.go
+++ b/oci/monitoring_metric.go
@@ -164,8 +164,9 @@ type MetricData struct {
 
 func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, granularity string, namespace string, metricName string, dimensionName string, dimensionValue string, compartmentId string, Region string) (*monitoring.SummarizeMetricsDataResponse, error) {
 	plugin.Logger(ctx).Trace("listMonitoringMetricStatistics")
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	// Create Session
-	session, err := monitoringService(ctx, d)
+	session, err := monitoringService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/monitoring_metric.go
+++ b/oci/monitoring_metric.go
@@ -162,9 +162,9 @@ type MetricData struct {
 	Timestamp     *time.Time
 }
 
-func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, granularity string, namespace string, metricName string, dimensionName string, dimensionValue string, compartmentId string, Region string) (*monitoring.SummarizeMetricsDataResponse, error) {
+func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, granularity string, namespace string, metricName string, dimensionName string, dimensionValue string, compartmentId string, region string) (*monitoring.SummarizeMetricsDataResponse, error) {
 	plugin.Logger(ctx).Trace("listMonitoringMetricStatistics")
-	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+
 	// Create Session
 	session, err := monitoringService(ctx, d, region)
 	if err != nil {
@@ -258,7 +258,7 @@ func listMonitoringMetricStatistics(ctx context.Context, d *plugin.QueryData, gr
 				SampleCount:    getStatisticForColumnByTimestamp(datapoint.Timestamp.Time.UTC(), *item.CompartmentId, metricDetailsCount),
 				Sum:            getStatisticForColumnByTimestamp(datapoint.Timestamp.Time.UTC(), *item.CompartmentId, metricDetailsSum),
 				Metadata:       item.Metadata,
-				Region:         Region,
+				Region:         region,
 			})
 		}
 	}

--- a/oci/service.go
+++ b/oci/service.go
@@ -892,7 +892,7 @@ func budgetService(ctx context.Context, d *plugin.QueryData, region string) (*se
 }
 
 // monitoringService returns the service client for OCI Monitoring Service
-func monitoringService(ctx context.Context, d *plugin.QueryData) (*session, error) {
+func monitoringService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
 	logger := plugin.Logger(ctx)
 	serviceCacheKey := fmt.Sprintf("metric explorer-%s", "region")
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
@@ -902,7 +902,7 @@ func monitoringService(ctx context.Context, d *plugin.QueryData) (*session, erro
 	// get oci config info
 	ociConfig := GetConfig(d.Connection)
 
-	provider, err := getProvider(ctx, d.ConnectionManager, "", ociConfig)
+	provider, err := getProvider(ctx, d.ConnectionManager, region, ociConfig)
 	if err != nil {
 		logger.Error("metricExplorerService", "getProvider.Error", err)
 		return nil, err


### PR DESCRIPTION
Metric statistics should show the details for resource available in multiple regions

SPC file: 
```
regions   = ["us-ashburn-1","ap-mumbai-1","ap-hyderabad-1"]
```

Output: 

```
> select * from oci_core_boot_volume_metric_read_ops_daily
+--------------------------------------------------------------------------------------------------+---------------+----------------+---------------------+---------+---------+--------------+-------+------
| id                                                                                               | metric_name   | namespace      | average             | maximum | minimum | sample_count | sum   | unit 
+--------------------------------------------------------------------------------------------------+---------------+----------------+---------------------+---------+---------+--------------+-------+------
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrkgj4b3bqifaszl3ycsphmjgbaveo2dj2o2rvt575auofjeelwuva | VolumeReadOps | oci_blockstore | 14.671881606765327  | 9572    | 0       | 2365         | 34699 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrogb2ksrzcclvgctbzk6z7dswtopikjlww2gstnzevor5ggnjvera | VolumeReadOps | oci_blockstore | 0.7726315789473684  | 1780    | 0       | 2375         | 1835  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrogb2ksrzcclvgctbzk6z7dswtopikjlww2gstnzevor5ggnjvera | VolumeReadOps | oci_blockstore | 69.77070063694268   | 9585    | 0       | 471          | 32862 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrwwxsexhztm2mx4cme3ygzeephqhxccl44bpxxwaqdopxs4q5mpya | VolumeReadOps | oci_blockstore | 69.18736842105262   | 9815    | 0       | 475          | 32864 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrwwxsexhztm2mx4cme3ygzeephqhxccl44bpxxwaqdopxs4q5mpya | VolumeReadOps | oci_blockstore | 0.7724021876314683  | 1779    | 0       | 2377         | 1836  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrjeucjefbtuuj7d5fnoxhsnchaxtecpy6b765akmtxy245642rc5a | VolumeReadOps | oci_blockstore | 14.930722891566266  | 11196   | 0       | 2324         | 34699 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrfazhl6l6d46rjluvle5il6kcjtwyeto7afqsmnsdkj7xdyyk2yrq | VolumeReadOps | oci_blockstore | 67.75670103092783   | 9888    | 0       | 485          | 32862 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrfazhl6l6d46rjluvle5il6kcjtwyeto7afqsmnsdkj7xdyyk2yrq | VolumeReadOps | oci_blockstore | 0.7720773759461732  | 1779    | 0       | 2378         | 1836  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrxesiodi3t5dkeefsopaw6lkxbndschwhkwrcsgfxiheqlnpdxplq | VolumeReadOps | oci_blockstore | 6.636593591905565   | 8317    | 0       | 2372         | 15742 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrxesiodi3t5dkeefsopaw6lkxbndschwhkwrcsgfxiheqlnpdxplq | VolumeReadOps | oci_blockstore | 315.96666666666664  | 9231    | 0       | 60           | 18958 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrtdlth32ebab6qfc4xnduedoqy5bef4vnuuvp5udyhow2alrjvfjq | VolumeReadOps | oci_blockstore | 377.64367816091954  | 13567   | 0       | 87           | 32855 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrtdlth32ebab6qfc4xnduedoqy5bef4vnuuvp5udyhow2alrjvfjq | VolumeReadOps | oci_blockstore | 0.7729570345408593  | 1780    | 0       | 2374         | 1835  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrt7rasfmg44xmhrvhzxnlxi52shp35ezq2m6ka7vonuzsszrrizkq | VolumeReadOps | oci_blockstore | 14.737154989384289  | 10882   | 0       | 2355         | 34706 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrfbawcyj4ndcokcfxehodi2mqs34hyms7i62cygnmyd5dyjws6lwa | VolumeReadOps | oci_blockstore | 14.76127659574468   | 10581   | 0       | 2350         | 34689 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrugiikxir6l4uwhh2opht4htkobszabnskklvfcse2qleosvni3na | VolumeReadOps | oci_blockstore | 0.7752951096121417  | 1780    | 0       | 2372         | 1839  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrugiikxir6l4uwhh2opht4htkobszabnskklvfcse2qleosvni3na | VolumeReadOps | oci_blockstore | 421.21794871794873  | 9501    | 0       | 78           | 32855 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrw6inoe2z6ylt4knscqz7my3ehpuoi5nequycqv4wgh2toxu6xbiq | VolumeReadOps | oci_blockstore | 0.7738947368421053  | 1780    | 0       | 2375         | 1838  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrw6inoe2z6ylt4knscqz7my3ehpuoi5nequycqv4wgh2toxu6xbiq | VolumeReadOps | oci_blockstore | 342.3125            | 11569   | 0       | 96           | 32862 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrt5pft3rfxyb27tyjhe4w5hi3jzetndbgg2mgy3y6pyhsubvksmvq | VolumeReadOps | oci_blockstore | 0.01808242220353238 | 25      | 0       | 2378         | 43    | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrt5pft3rfxyb27tyjhe4w5hi3jzetndbgg2mgy3y6pyhsubvksmvq | VolumeReadOps | oci_blockstore | 72.18958333333333   | 11878   | 0       | 480          | 34651 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrykb34glmpcg6ylp2mvyyds4zoax2si7kvxystueiknj3xc5lcfzq | VolumeReadOps | oci_blockstore | 15.042931483087598  | 9952    | 0       | 2306         | 34689 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrlt32udth3f7s5qejnjmcmk2hpaadagpbamxfnxpufs3mbvcgrwgq | VolumeReadOps | oci_blockstore | 69.47780126849894   | 12811   | 0       | 473          | 32863 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrlt32udth3f7s5qejnjmcmk2hpaadagpbamxfnxpufs3mbvcgrwgq | VolumeReadOps | oci_blockstore | 0.7694572991165335  | 1780    | 0       | 2377         | 1829  | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrooz6yu5vgo6fvrzxdsn7hk7tgf6dlapqyjkzjragvppl2jlldvlq | VolumeReadOps | oci_blockstore | 14.843028229255774  | 9714    | 0       | 2338         | 34703 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrordzxuux7hhcukpf735oumimgt7rnu4tv5qzzxqgn56w42ud2zma | VolumeReadOps | oci_blockstore | 371.6470588235294   | 10708   | 0       | 51           | 18954 | opera
| ocid1.bootvolume.oc1.ap-hyderabad-1.abuhsljrordzxuux7hhcukpf735oumimgt7rnu4tv5qzzxqgn56w42ud2zma | VolumeReadOps | oci_blockstore | 6.6372838464782795  | 8000    | 0       | 2371         | 15737 | opera
+--------------------------------------------------------------------------------------------------+---------------+----------------+---------------------+---------+---------+--------------+-------+------
(END)

```