### PR TITLE
Fix get call issue in tables where we are using zone from GetMatrixItem. Closes #262

### DIFF
--- a/oci-test/tests/oci_file_storage_file_system/test-turbot-expected.json
+++ b/oci-test/tests/oci_file_storage_file_system/test-turbot-expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "region": "ap_mumbai_1",
+    "region": "{{ output.region.value }}",
     "tenant_id": "{{ output.tenancy_ocid.value }}",
     "title": "{{ output.resource_name.value }}"
   }

--- a/oci/table_oci_core_block_volume_replica.go
+++ b/oci/table_oci_core_block_volume_replica.go
@@ -183,8 +183,8 @@ func getCoreBlockVolumeReplica(ctx context.Context, d *plugin.QueryData, _ *plug
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("getCoreBlockVolumeReplica", "Compartment", compartment, "OCI_Zone", zone)
 
-	// Restrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 		return nil, nil
 	}
 

--- a/oci/table_oci_core_boot_volume.go
+++ b/oci/table_oci_core_boot_volume.go
@@ -218,8 +218,8 @@ func getBootVolume(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.getBootVolume", "Compartment", compartment, "OCI_zone", zone)
 
-	// Restrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 		return nil, nil
 	}
 

--- a/oci/table_oci_core_boot_volume_attachment.go
+++ b/oci/table_oci_core_boot_volume_attachment.go
@@ -164,8 +164,8 @@ func getCoreBootVolumeAttachment(ctx context.Context, d *plugin.QueryData, _ *pl
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("getCoreBootVolumeAttachment", "Compartment", compartment, "OCI_Zone", zone)
 
-	// Restrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 		return nil, nil
 	}
 

--- a/oci/table_oci_core_boot_volume_replica.go
+++ b/oci/table_oci_core_boot_volume_replica.go
@@ -189,8 +189,8 @@ func getCoreBootVolumeReplica(ctx context.Context, d *plugin.QueryData, _ *plugi
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("getCoreBootVolumeReplica", "Compartment", compartment, "OCI_Zone", zone)
 
-	// Restrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 		return nil, nil
 	}
 

--- a/oci/table_oci_file_storage_file_system.go
+++ b/oci/table_oci_file_storage_file_system.go
@@ -198,10 +198,10 @@ func getFileStorageFileSystem(ctx context.Context, d *plugin.QueryData, h *plugi
 		id = *fileSystem.Id
 	} else {
 		id = d.KeyColumnQuals["id"].GetStringValue()
-		// Restrict the api call to only root compartment/ per region
-		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
-			return nil, nil
-		}
+		// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
+		return nil, nil
+	}
 	}
 
 	// handle empty application id in get call

--- a/oci/table_oci_file_storage_file_system.go
+++ b/oci/table_oci_file_storage_file_system.go
@@ -185,12 +185,11 @@ func listFileStorageFileSystems(ctx context.Context, d *plugin.QueryData, _ *plu
 //// HYDRATE FUNCTION
 
 func getFileStorageFileSystem(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getFileStorageFileSystem")
 	logger := plugin.Logger(ctx)
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
-	logger.Debug("getFunctionsApplication", "Compartment", compartment, "OCI_ZONE", zone)
+	logger.Debug("getFileStorageFileSystem", "Compartment", compartment, "OCI_ZONE", zone)
 
 	var id string
 	if h.Item != nil {
@@ -199,9 +198,9 @@ func getFileStorageFileSystem(ctx context.Context, d *plugin.QueryData, h *plugi
 	} else {
 		id = d.KeyColumnQuals["id"].GetStringValue()
 		// Restrict the api call to only root compartment and one zone/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
-		return nil, nil
-	}
+		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
+			return nil, nil
+		}
 	}
 
 	// handle empty application id in get call

--- a/oci/table_oci_file_storage_snapshot.go
+++ b/oci/table_oci_file_storage_snapshot.go
@@ -184,11 +184,12 @@ func getFileStorageSnapshot(ctx context.Context, d *plugin.QueryData, h *plugin.
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("getFileStorageSnapshot", "Compartment", compartment, "OCI_ZONE", zone)
 
-	id := d.KeyColumnQuals["id"].GetStringValue()
-	// Restrict the api call to only root compartment/ per region
-	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 		return nil, nil
 	}
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
 
 	// handle empty snapshot id in get call
 	if id == "" {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
SETUP: tests/oci_file_storage_file_system []

PRETEST: tests/oci_file_storage_file_system

TEST: tests/oci_file_storage_file_system
Running terraform
oci_file_storage_file_system.named_test_resource: Creating...
oci_file_storage_file_system.named_test_resource: Creation complete after 4s [id=ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haronfqwillqojxwiotjmfsc2ylefuzqaaaa]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

availability_domain = "TvRS:US-ASHBURN-AD-1"
freeform_tags = tomap({
  "Name" = "steampipetest5807"
})
region = "us-ashburn-1"
resource_id = "ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haronfqwillqojxwiotjmfsc2ylefuzqaaaa"
resource_name = "steampipetest5807"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "availability_domain": "TvRS:US-ASHBURN-AD-1",
    "display_name": "steampipetest5807",
    "freeform_tags": {
      "Name": "steampipetest5807"
    },
    "id": "ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haronfqwillqojxwiotjmfsc2ylefuzqaaaa",
    "is_clone_parent": false,
    "is_hydrated": true,
    "lifecycle_state": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "availability_domain": "TvRS:US-ASHBURN-AD-1",
    "display_name": "steampipetest5807",
    "id": "ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haronfqwillqojxwiotjmfsc2ylefuzqaaaa",
    "lifecycle_state": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "us-ashburn-1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest5807"
  }
]
✔ PASSED

POSTTEST: tests/oci_file_storage_file_system

TEARDOWN: tests/oci_file_storage_file_system

SUMMARY:

1/1 passed.
```

</details>

# Example query results
<details>
  <summary>Results</summary>

  # Examples with multizone
```
> select * from oci_file_storage_file_system where id = 'ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haoenfqwillqojxwiotjmfsc2ylefuzqaaaa'
+-----------------------------+---------------------------------------------------------------------------+-----------------+----------------------+---------------------+-----------------+-------------+--
| display_name                | id                                                                        | lifecycle_state | availability_domain  | time_created        | is_clone_parent | is_hydrated | k
+-----------------------------+---------------------------------------------------------------------------+-----------------+----------------------+---------------------+-----------------+-------------+--
| FileSystem-20210804-0647-10 | ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haoenfqwillqojxwiotjmfsc2ylefuzqaaaa | ACTIVE          | TvRS:US-ASHBURN-AD-1 | 2021-08-04 06:47:25 | false           | true        |  
+-----------------------------+---------------------------------------------------------------------------+-----------------+----------------------+---------------------+-----------------+-------------+--

> select * from oci_core_boot_volume where id = 'ocid1.bootvolume.oc1.iad.abuwcljtrdvfi4pjrbikeod6b5lh7cd3oubfj4lbp7msxadepwkw5meslmaa'
+---------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+----------------------+-----------------
| id                                                                                    | display_name                         | lifecycle_state | volume_group_id | availability_domain  | time_created    
+---------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+----------------------+-----------------
| ocid1.bootvolume.oc1.iad.abuwcljtrdvfi4pjrbikeod6b5lh7cd3oubfj4lbp7msxadepwkw5meslmaa | instance-20210804-1205 (Boot Volume) | AVAILABLE       | <null>          | TvRS:US-ASHBURN-AD-1 | 2021-08-04 06:35
+---------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+----------------------+-----------------

> select * from oci_core_boot_volume_attachment where id = 'ocid1.instance.oc1.iad.anuwcljt6igdexacqpi6kmiv7zjqnekosnhrkj77m6z67j4bcghpaby3xena'
+-------------------------------------------------------------------------------------+-------------------------------------+-------------------------------------------------------------------------------
| id                                                                                  | display_name                        | boot_volume_id                                                                
+-------------------------------------------------------------------------------------+-------------------------------------+-------------------------------------------------------------------------------
| ocid1.instance.oc1.iad.anuwcljt6igdexacqpi6kmiv7zjqnekosnhrkj77m6z67j4bcghpaby3xena | Remote boot attachment for instance | ocid1.bootvolume.oc1.iad.abuwcljtrdvfi4pjrbikeod6b5lh7cd3oubfj4lbp7msxadepwkw5
+-------------------------------------------------------------------------------------+-------------------------------------+-------------------------------------------------------------------------------

> select * from oci_file_storage_snapshot where id = 'ocid1.snapshot.oc1.iad.aaaaaaaaaaaaaaabaaaaaaabyoa4i2lbmqwxa4tpmq5gsylefvqwiljt'
+---------------------------+---------------------------------------------------------------------------------+-----------------+---------------------+-----------------------------------------------------
| name                      | id                                                                              | lifecycle_state | time_created        | file_system_id                                      
+---------------------------+---------------------------------------------------------------------------------+-----------------+---------------------+-----------------------------------------------------
| Snapshot-20210804-0701-53 | ocid1.snapshot.oc1.iad.aaaaaaaaaaaaaaabaaaaaaabyoa4i2lbmqwxa4tpmq5gsylefvqwiljt | ACTIVE          | 2021-08-04 07:01:55 | ocid1.filesystem.oc1.iad.aaaaaaaaaaa4haoenfqwillqojx
+---------------------------+---------------------------------------------------------------------------------+-----------------+---------------------+-----------------------------------------------------
```
# Examples with singlezone

```
> select * from oci_core_boot_volume where id = 'ocid1.bootvolume.oc1.ap-mumbai-1.abrg6ljrgmbkcxwwpifylq5e3bnq7pz2qcibfd42ckzzgmqe5jjy4qa23eaa'
+-----------------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+-----------------------+--------
| id                                                                                            | display_name                         | lifecycle_state | volume_group_id | availability_domain   | time_cr
+-----------------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+-----------------------+--------
| ocid1.bootvolume.oc1.ap-mumbai-1.abrg6ljrgmbkcxwwpifylq5e3bnq7pz2qcibfd42ckzzgmqe5jjy4qa23eaa | instance-20210804-1234 (Boot Volume) | AVAILABLE       | <null>          | TvRS:AP-MUMBAI-1-AD-1 | 2021-08
+-----------------------------------------------------------------------------------------------+--------------------------------------+-----------------+-----------------+-----------------------+--------

> select * from oci_core_boot_volume_attachment where id = 'ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexaceyxlkr26lzke425dbmkluqqahbz2scz47cujvgss4exa'
+---------------------------------------------------------------------------------------------+-------------------------------------+-----------------------------------------------------------------------
| id                                                                                          | display_name                        | boot_volume_id                                                        
+---------------------------------------------------------------------------------------------+-------------------------------------+-----------------------------------------------------------------------
| ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexaceyxlkr26lzke425dbmkluqqahbz2scz47cujvgss4exa | Remote boot attachment for instance | ocid1.bootvolume.oc1.ap-mumbai-1.abrg6ljrgmbkcxwwpifylq5e3bnq7pz2qcibf
+---------------------------------------------------------------------------------------------+-------------------------------------+-----------------------------------------------------------------------

```

</details>
