### PR TITLE
Update oci_core_image table to list only platform(standard) images. Closes #212

### DIFF
--- a/docs/tables/oci_core_image.md
+++ b/docs/tables/oci_core_image.md
@@ -28,5 +28,5 @@ select
 from
   oci_core_image
 where
-  launch_options ->> 'isPvEncryptionInTransitEnabled'  = 'false';
+  launch_options ->> 'isPvEncryptionInTransitEnabled' = 'false';
 ```

--- a/docs/tables/oci_core_image.md
+++ b/docs/tables/oci_core_image.md
@@ -30,16 +30,3 @@ from
 where
   launch_options ->> 'isPvEncryptionInTransitEnabled'  = 'false';
 ```
-
-### List custom images
-
-```sql
-select
-  display_name,
-  id,
-  lifecycle_state
-from
-  oci_core_image
-where
-  tenant_id is not null;
-```

--- a/oci-test/tests/oci_core_image/test-get-expected.json
+++ b/oci-test/tests/oci_core_image/test-get-expected.json
@@ -1,9 +1,6 @@
 [
   {
-    "display_name": "{{ resourceName }}",
-    "freeform_tags": {
-      "Name": "{{ resourceName }}"
-    },
+    "display_name": "{{ output.resource_name.value }}",
     "id": "{{ output.resource_id.value }}",
     "lifecycle_state": "{{ output.lifecycle_state.value }}"
   }

--- a/oci-test/tests/oci_core_image/test-get-query.sql
+++ b/oci-test/tests/oci_core_image/test-get-query.sql
@@ -1,3 +1,3 @@
-select display_name, id, freeform_tags, lifecycle_state
+select display_name, id, lifecycle_state
 from oci.oci_core_image
 where id = '{{ output.resource_id.value }}';

--- a/oci-test/tests/oci_core_image/test-list-expected.json
+++ b/oci-test/tests/oci_core_image/test-list-expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "display_name": "{{ resourceName }}",
+    "display_name": "{{ output.resource_name.value }}",
     "id": "{{ output.resource_id.value }}",
     "operating_system": "{{ output.operating_system.value }}",
     "operating_system_version": "{{ output.operating_system_version.value }}"

--- a/oci-test/tests/oci_core_image/test-list-query.sql
+++ b/oci-test/tests/oci_core_image/test-list-query.sql
@@ -1,3 +1,3 @@
 select display_name, id, operating_system, operating_system_version
 from oci.oci_core_image
-where display_name = '{{ resourceName }}';
+where display_name = '{{ output.resource_name.value }}' and region = '{{ output.region.value }}';

--- a/oci-test/tests/oci_core_image/test-turbot-expected.json
+++ b/oci-test/tests/oci_core_image/test-turbot-expected.json
@@ -1,6 +1,6 @@
 [
   {
     "tenant_id": "{{ output.tenancy_ocid.value }}",
-    "title": "{{ resourceName }}"
+    "title": "{{ output.resource_name.value  }}"
   }
 ]


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/oci_core_image []

PRETEST: tests/oci_core_image

TEST: tests/oci_core_image
Running terraform
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci compute image list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --region ap-mumbai-1 --output json > /private/var/folders/d8/gsp6f_cn3359xnt_gs3cts_80000gn/T/tests/oci_core_image/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: This operation supports pagination and not all resources were returned.  Re-run using the --all option to auto paginate and list all resources.
null_resource.named_test_resource: Creation complete after 5s [id=1433710729676136767]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=804f99e50faeb03507ac9191bc451237cb89626a]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

lifecycle_state = "AVAILABLE"
operating_system = "Windows"
operating_system_version = "Server 2019 Standard"
region = "ap-mumbai-1"
resource_id = "ocid1.image.oc1.ap-mumbai-1.aaaaaaaa53wlowknunmwe3ygptjnuxbcjvmkkvseaijenx6yle5j4jtsneia"
resource_name = "Windows-Server-2019-Standard-Edition-VM-Gen2-2021.07.01-0"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "display_name": "Windows-Server-2019-Standard-Edition-VM-Gen2-2021.07.01-0",
    "id": "ocid1.image.oc1.ap-mumbai-1.aaaaaaaa53wlowknunmwe3ygptjnuxbcjvmkkvseaijenx6yle5j4jtsneia",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "Windows-Server-2019-Standard-Edition-VM-Gen2-2021.07.01-0",
    "id": "ocid1.image.oc1.ap-mumbai-1.aaaaaaaa53wlowknunmwe3ygptjnuxbcjvmkkvseaijenx6yle5j4jtsneia",
    "operating_system": "Windows",
    "operating_system_version": "Server 2019 Standard"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "Windows-Server-2019-Standard-Edition-VM-Gen2-2021.07.01-0"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_image

TEARDOWN: tests/oci_core_image

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_core_image where id = 'ocid1.image.oc1.ap-mumbai-1.aaaaaaaabsx6daorv2rid4b4ip5chaahzefmrndao3zfv5vhypjkulva6zqq'
+----------------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+---------------
| display_name                           | id                                                                                       | lifecycle_state | time_created        | base_image_id | create_image_a
+----------------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+---------------
| Oracle-Linux-8.2-Gen2-GPU-2020.11.10-0 | ocid1.image.oc1.ap-mumbai-1.aaaaaaaabsx6daorv2rid4b4ip5chaahzefmrndao3zfv5vhypjkulva6zqq | AVAILABLE       | 2020-11-07 05:56:32 | <null>        | true          
+----------------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+---------------
> select * from oci_core_image where display_name = 'Oracle-Linux-7.9-2021.05.12-0'
+-------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+----------------------+-
| display_name                  | id                                                                                       | lifecycle_state | time_created        | base_image_id | create_image_allowed | 
+-------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+----------------------+-
| Oracle-Linux-7.9-2021.05.12-0 | ocid1.image.oc1.ap-mumbai-1.aaaaaaaamsqdylsrea2wupqwlze7gruemtqc3cpi3ece2njcp6l625thev4q | AVAILABLE       | 2021-05-20 18:10:42 | <null>        | true                 | 
| Oracle-Linux-7.9-2021.05.12-0 | ocid1.image.oc1.iad.aaaaaaaamoajldhwrmbzx7s4xnrajj5b7nfrnutuebgwne4bxc7vpiap3gga         | AVAILABLE       | 2021-05-20 18:06:21 | <null>        | true                 | 
+-------------------------------+------------------------------------------------------------------------------------------+-----------------+---------------------+---------------+----------------------+-

> select compartment_id,tenant_id from oci_core_image where id = 'ocid1.image.oc1.ap-mumbai-1.aaaaaaaabsx6daorv2rid4b4ip5chaahzefmrndao3zfv5vhypjkulva6zqq'
+---------------------------------------------------------------------------------+---------------------------------------------------------------------------------+
| compartment_id                                                                  | tenant_id                                                                       |
+---------------------------------------------------------------------------------+---------------------------------------------------------------------------------+
| ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq | ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq |
+---------------------------------------------------------------------------------+---------------------------------------------------------------------------------+

```
</details>
