### PR TITLE
Fix integration test issues. closes #214

### DIFF
--- a/oci-test/tests/oci_cloud_guard_configuration/test-list-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-list-query.sql
@@ -1,3 +1,3 @@
 select reporting_region, self_manage_resources
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}';
+where reporting_region = '{{ output.reporting_region.value }}';

--- a/oci-test/tests/oci_cloud_guard_configuration/test-not-found-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-not-found-query.sql
@@ -1,3 +1,3 @@
-select region
+select reporting_region
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}::dummy';
+where reporting_region = '{{ output.reporting_region.value }}::dummy';

--- a/oci-test/tests/oci_cloud_guard_configuration/test-turbot-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select tenant_id
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}';
+where reporting_region = '{{ output.reporting_region.value }}';

--- a/oci-test/tests/oci_cloud_guard_detector_recipe/variables.tf
+++ b/oci-test/tests/oci_cloud_guard_detector_recipe/variables.tf
@@ -16,9 +16,10 @@ variable "config_file_profile" {
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 
+# we are not creating any resource so we have to pass the reporting region where resorce will be available
 variable "region" {
   type        = string
-  default     = "ap-mumbai-1"
+  default     = "ap-hyderabad-1"
   description = "OCI region used for the test. Does not work with default region in config, so must be defined here."
 }
 
@@ -27,21 +28,48 @@ provider "oci" {
   config_file_profile = var.config_file_profile
 }
 
-resource "oci_cloud_guard_detector_recipe" "named_test_resource" {
-  #Required
-  compartment_id            = var.tenancy_ocid
-  display_name              = var.resource_name
-  source_detector_recipe_id = oci_cloud_guard_detector_recipe.named_test_resource.id
+locals {
+  path = "${path.cwd}/output.json"
+}
+
+resource "null_resource" "named_test_resource" {
+  provisioner "local-exec" {
+    command = "oci cloud-guard detector-recipe list --compartment-id ${var.tenancy_ocid} --all --output json > ${local.path}"
+  }
+}
+
+data "local_file" "input" {
+  depends_on = [null_resource.named_test_resource]
+  filename   = local.path
 }
 
 output "resource_name" {
-  value = var.resource_name
+  depends_on = [null_resource.named_test_resource]
+  value = jsondecode(data.local_file.input.content).data.items[0].display-name
 }
+
+output "resource_state" {
+  depends_on = [
+     null_resource.named_test_resource
+  ]
+  value = jsondecode(data.local_file.input.content).data.items[0].lifecycle-state
+}
+
+output "source_detector_id" {
+  depends_on = [
+     null_resource.named_test_resource
+  ]
+  value = jsondecode(data.local_file.input.content).data.items[0].source-detector-recipe-id
+}
+
 
 output "tenancy_ocid" {
   value = var.tenancy_ocid
 }
 
 output "resource_id" {
-  value = oci_cloud_guard_detector_recipe.named_test_resource.id
+  depends_on = [
+     null_resource.named_test_resource
+  ]
+  value = jsondecode(data.local_file.input.content).data.items[0].id
 }

--- a/oci-test/tests/oci_core_drg/variables.tf
+++ b/oci-test/tests/oci_core_drg/variables.tf
@@ -12,7 +12,7 @@ variable "tenancy_ocid" {
 
 variable "config_file_profile" {
   type        = string
-  default     = "Default"
+  default     = "DEFAULT"
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/oci-test/tests/oci_core_internet_gateway/variables.tf
+++ b/oci-test/tests/oci_core_internet_gateway/variables.tf
@@ -12,7 +12,7 @@ variable "tenancy_ocid" {
 
 variable "config_file_profile" {
   type        = string
-  default     = "Default"
+  default     = "DEFAULT"
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/oci-test/tests/oci_core_volume/variables.tf
+++ b/oci-test/tests/oci_core_volume/variables.tf
@@ -12,7 +12,7 @@ variable "tenancy_ocid" {
 
 variable "config_file_profile" {
   type        = string
-  default     = "default"
+  default     = "DEFAULT"
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/oci-test/tests/oci_dns_rrset/test-list-expected.json
+++ b/oci-test/tests/oci_dns_rrset/test-list-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "domain": "{{ output.domain.value }}",
-    "is_protected": "true",
+    "is_protected": true,
     "rtype": "{{ output.rtype.value }}",
     "ttl": "86400"
   }

--- a/oci-test/tests/oci_functions_application/variables.tf
+++ b/oci-test/tests/oci_functions_application/variables.tf
@@ -12,7 +12,7 @@ variable "tenancy_ocid" {
 
 variable "config_file_profile" {
   type        = string
-  default     = " DEFAULT"
+  default     = "DEFAULT"
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/oci-test/tests/oci_identity_dynamic_group/variables.tf
+++ b/oci-test/tests/oci_identity_dynamic_group/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "config_file_profile" {
   type        = string
-  default     = "Default"
+  default     = "DEFAULT"
   description = "OCI credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/oci/table_oci_cloud_guard_configuration.go
+++ b/oci/table_oci_cloud_guard_configuration.go
@@ -53,7 +53,7 @@ func tableCloudGuardConfiguration(_ context.Context) *plugin.Table {
 
 func listCloudGuardConfigurations(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, "")
 	if err != nil {
 		return nil, err
 	}

--- a/oci/table_oci_cloud_guard_detector_recipe.go
+++ b/oci/table_oci_cloud_guard_detector_recipe.go
@@ -25,7 +25,7 @@ func tableCloudGuardDetectorRecipe(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCloudGuardDetectorRecipes,
 		},
-		GetMatrixItem: BuildCompartmentList,
+		GetMatrixItem: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -147,10 +147,11 @@ func tableCloudGuardDetectorRecipe(_ context.Context) *plugin.Table {
 func listCloudGuardDetectorRecipes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Trace("oci.listCloudGuardDetectorRecipes", "Compartment", compartment)
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +187,7 @@ func listCloudGuardDetectorRecipes(ctx context.Context, d *plugin.QueryData, _ *
 func getCloudGuardDetectorRecipe(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.getCloudGuardDetectorRecipe", "Compartment", compartment)
 
 	var id string
@@ -200,7 +202,7 @@ func getCloudGuardDetectorRecipe(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/table_oci_cloud_guard_managed_list.go
+++ b/oci/table_oci_cloud_guard_managed_list.go
@@ -25,7 +25,7 @@ func tableCloudGuardManagedList(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCloudGuardManagedLists,
 		},
-		GetMatrixItem: BuildCompartmentList,
+		GetMatrixItem: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -151,10 +151,11 @@ func tableCloudGuardManagedList(_ context.Context) *plugin.Table {
 func listCloudGuardManagedLists(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.listCloudGuardManagedLists", "Compartment", compartment)
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
@@ -190,6 +191,7 @@ func listCloudGuardManagedLists(ctx context.Context, d *plugin.QueryData, _ *plu
 func getCloudGuardManagedList(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.getCloudGuardManagedList", "Compartment", compartment)
 
 	// Rstrict the api call to only root compartment/ per region
@@ -204,7 +206,7 @@ func getCloudGuardManagedList(ctx context.Context, d *plugin.QueryData, h *plugi
 		return nil, nil
 	}
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/table_oci_cloud_guard_responder_recipe.go
+++ b/oci/table_oci_cloud_guard_responder_recipe.go
@@ -25,7 +25,7 @@ func tableCloudGuardResponderRecipe(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCloudGuardResponderRecipes,
 		},
-		GetMatrixItem: BuildCompartmentList,
+		GetMatrixItem: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -147,10 +147,11 @@ func tableCloudGuardResponderRecipe(_ context.Context) *plugin.Table {
 func listCloudGuardResponderRecipes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.listCloudGuardResponderRecipes", "Compartment", compartment)
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
@@ -186,6 +187,7 @@ func listCloudGuardResponderRecipes(ctx context.Context, d *plugin.QueryData, _ 
 func getCloudGuardResponderRecipe(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.getCloudGuardResponderRecipe", "Compartment", compartment)
 
 	var id string
@@ -205,7 +207,7 @@ func getCloudGuardResponderRecipe(ctx context.Context, d *plugin.QueryData, h *p
 	}
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/table_oci_cloud_guard_target.go
+++ b/oci/table_oci_cloud_guard_target.go
@@ -25,7 +25,7 @@ func tableCloudGuardTarget(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCloudGuardTargets,
 		},
-		GetMatrixItem: BuildCompartmentList,
+		GetMatrixItem: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -160,10 +160,11 @@ func tableCloudGuardTarget(_ context.Context) *plugin.Table {
 func listCloudGuardTargets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.listCloudGuardTargets", "Compartment", compartment)
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
@@ -199,6 +200,7 @@ func listCloudGuardTargets(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 func getCloudGuardTarget(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	logger.Debug("oci.getCloudGuardTarget", "Compartment", compartment)
 
 	var id string
@@ -218,7 +220,7 @@ func getCloudGuardTarget(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_identity_tenancy' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_identity_tenancy []

PRETEST: tests/oci_identity_tenancy

TEST: tests/oci_identity_tenancy
Running terraform
null_resource.named_test_resource: Creating...
null_resource.retention_period: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.retention_period: Provisioning with 'local-exec'...
null_resource.retention_period (local-exec): Executing: ["/bin/sh" "-c" "oci audit config get --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq > /private/var/folders/5q/jqv70bxs7g73gwgv5tvl80l40000gn/T/tests/oci_identity_tenancy/terraform/test/retention_period.json"]
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci iam tenancy get --tenancy-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq > /private/var/folders/5q/jqv70bxs7g73gwgv5tvl80l40000gn/T/tests/oci_identity_tenancy/terraform/test/identity_tenancy.json"]
null_resource.retention_period: Creation complete after 2s [id=79172035678274471]
data.local_file.periodInput: Refreshing state...
null_resource.named_test_resource: Creation complete after 2s [id=1118091585366723976]
data.local_file.input: Refreshing state...

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

description = lalit
resourceName = turbot
resource_id = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq
retention_period_days = 365
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-hydrate-query.sql

[
  {
    "id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "name": "turbot",
    "retention_period_days": 365
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "description": "lalit",
    "id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "name": "turbot",
    "retention_period_days": 365
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "turbot"
  }
]
✔ PASSED

POSTTEST: tests/oci_identity_tenancy

TEARDOWN: tests/oci_identity_tenancy

SUMMARY:

1/1 passed.

==============================================================================================================================================================================

Test names: [ 'tests/oci_autoscaling_auto_scaling_configuration' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_autoscaling_auto_scaling_configuration []

PRETEST: tests/oci_autoscaling_auto_scaling_configuration

TEST: tests/oci_autoscaling_auto_scaling_configuration
Running terraform
data.oci_objectstorage_namespace.test_namespace: Refreshing state...
oci_core_vcn.named_test_resource: Creating...
oci_core_volume.test_volume: Creating...
oci_objectstorage_bucket.named_test_resource: Creating...
oci_objectstorage_bucket.named_test_resource: Creation complete after 1s [id=n/bmqeqvslavsz/b/steampipetest3714]
oci_objectstorage_object.test_object: Creating...
oci_core_vcn.named_test_resource: Creation complete after 2s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaagiir7kn2ck5pevyggl364gufrs75gvamfguvr2o7atvq]
oci_core_subnet.named_test_resource: Creating...
oci_objectstorage_object.test_object: Creation complete after 1s [id=n/bmqeqvslavsz/b/steampipetest3714/o/test]
oci_core_image.test_image: Creating...
oci_core_subnet.named_test_resource: Creation complete after 2s [id=ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaaeypomrvm4wzo4c5dipdcwbbqf4d4jsidytcuyttdrrr5prodcsvq]
oci_core_volume.test_volume: Still creating... [10s elapsed]
oci_core_image.test_image: Still creating... [10s elapsed]
oci_core_volume.test_volume: Creation complete after 15s [id=ocid1.volume.oc1.ap-mumbai-1.abrg6ljr65wbvjwrzvw5fw3tfewg6llhpyf4jameemkpe6mle3zi64frxolq]
oci_core_image.test_image: Still creating... [20s elapsed]
oci_core_image.test_image: Still creating... [30s elapsed]
oci_core_image.test_image: Still creating... [40s elapsed]
oci_core_image.test_image: Still creating... [50s elapsed]
oci_core_image.test_image: Still creating... [1m0s elapsed]
oci_core_image.test_image: Still creating... [1m10s elapsed]
oci_core_image.test_image: Still creating... [1m20s elapsed]
oci_core_image.test_image: Still creating... [1m30s elapsed]
oci_core_image.test_image: Still creating... [1m40s elapsed]
oci_core_image.test_image: Still creating... [1m50s elapsed]
oci_core_image.test_image: Still creating... [2m0s elapsed]
oci_core_image.test_image: Still creating... [2m10s elapsed]
oci_core_image.test_image: Still creating... [2m20s elapsed]
oci_core_image.test_image: Still creating... [2m30s elapsed]
oci_core_image.test_image: Still creating... [2m40s elapsed]
oci_core_image.test_image: Still creating... [2m50s elapsed]
oci_core_image.test_image: Still creating... [3m0s elapsed]
oci_core_image.test_image: Still creating... [3m10s elapsed]
oci_core_image.test_image: Still creating... [3m20s elapsed]
oci_core_image.test_image: Still creating... [3m30s elapsed]
oci_core_image.test_image: Still creating... [3m40s elapsed]
oci_core_image.test_image: Still creating... [3m50s elapsed]
oci_core_image.test_image: Still creating... [4m0s elapsed]
oci_core_image.test_image: Still creating... [4m10s elapsed]
oci_core_image.test_image: Still creating... [4m20s elapsed]
oci_core_image.test_image: Still creating... [4m30s elapsed]
oci_core_image.test_image: Still creating... [4m40s elapsed]
oci_core_image.test_image: Still creating... [4m50s elapsed]
oci_core_image.test_image: Still creating... [5m0s elapsed]
oci_core_image.test_image: Still creating... [5m10s elapsed]
oci_core_image.test_image: Still creating... [5m20s elapsed]
oci_core_image.test_image: Still creating... [5m30s elapsed]
oci_core_image.test_image: Still creating... [5m40s elapsed]
oci_core_image.test_image: Still creating... [5m50s elapsed]
oci_core_image.test_image: Still creating... [6m0s elapsed]
oci_core_image.test_image: Still creating... [6m10s elapsed]
oci_core_image.test_image: Still creating... [6m20s elapsed]
oci_core_image.test_image: Still creating... [6m30s elapsed]
oci_core_image.test_image: Still creating... [6m40s elapsed]
oci_core_image.test_image: Still creating... [6m50s elapsed]
oci_core_image.test_image: Still creating... [7m0s elapsed]
oci_core_image.test_image: Still creating... [7m10s elapsed]
oci_core_image.test_image: Still creating... [7m20s elapsed]
oci_core_image.test_image: Still creating... [7m30s elapsed]
oci_core_image.test_image: Still creating... [7m40s elapsed]
oci_core_image.test_image: Still creating... [7m50s elapsed]
oci_core_image.test_image: Still creating... [8m0s elapsed]
oci_core_image.test_image: Still creating... [8m10s elapsed]
oci_core_image.test_image: Still creating... [8m20s elapsed]
oci_core_image.test_image: Still creating... [8m30s elapsed]
oci_core_image.test_image: Still creating... [8m40s elapsed]
oci_core_image.test_image: Still creating... [8m50s elapsed]
oci_core_image.test_image: Still creating... [9m0s elapsed]
oci_core_image.test_image: Still creating... [9m10s elapsed]
oci_core_image.test_image: Still creating... [9m20s elapsed]
oci_core_image.test_image: Still creating... [9m30s elapsed]
oci_core_image.test_image: Still creating... [9m40s elapsed]
oci_core_image.test_image: Still creating... [9m50s elapsed]
oci_core_image.test_image: Still creating... [10m0s elapsed]
oci_core_image.test_image: Still creating... [10m10s elapsed]
oci_core_image.test_image: Still creating... [10m20s elapsed]
oci_core_image.test_image: Still creating... [10m30s elapsed]
oci_core_image.test_image: Still creating... [10m40s elapsed]
oci_core_image.test_image: Still creating... [10m50s elapsed]
oci_core_image.test_image: Still creating... [11m0s elapsed]
oci_core_image.test_image: Still creating... [11m10s elapsed]
oci_core_image.test_image: Still creating... [11m20s elapsed]
oci_core_image.test_image: Still creating... [11m30s elapsed]
oci_core_image.test_image: Still creating... [11m40s elapsed]
oci_core_image.test_image: Still creating... [11m50s elapsed]
oci_core_image.test_image: Still creating... [12m0s elapsed]
oci_core_image.test_image: Still creating... [12m10s elapsed]
oci_core_image.test_image: Still creating... [12m20s elapsed]
oci_core_image.test_image: Still creating... [12m30s elapsed]
oci_core_image.test_image: Still creating... [12m40s elapsed]
oci_core_image.test_image: Still creating... [12m50s elapsed]
oci_core_image.test_image: Creation complete after 12m58s [id=ocid1.image.oc1.ap-mumbai-1.aaaaaaaarqmgnojf4xxwfrcs7c3rnchth623dq5ct5rt2bznwqiaqipcvrgq]
oci_core_instance_configuration.test_instance_configuration: Creating...
oci_core_instance_configuration.test_instance_configuration: Creation complete after 0s [id=ocid1.instanceconfiguration.oc1.ap-mumbai-1.aaaaaaaavydh2tffahb2lunjlden4vkhkl4pm7ygs3xpeypx2a5h6vn2yj2q]
oci_core_instance_pool.test_instance_pool: Creating...
oci_core_instance_pool.test_instance_pool: Still creating... [10s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [20s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [30s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [40s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [50s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [1m0s elapsed]
oci_core_instance_pool.test_instance_pool: Still creating... [1m10s elapsed]
oci_core_instance_pool.test_instance_pool: Creation complete after 1m17s [id=ocid1.instancepool.oc1.ap-mumbai-1.aaaaaaaaqunafrycbgkzxxqgx7pasquk7hkxxikji3ga5k4bhi24y3t2be2a]
oci_autoscaling_auto_scaling_configuration.test_auto_scaling_configuration: Creating...
oci_autoscaling_auto_scaling_configuration.test_auto_scaling_configuration: Creation complete after 4s [id=ocid1.autoscalingconfiguration.oc1.ap-mumbai-1.aaaaaaaaivm5mllzyc5hwzqezzcyo3l4nfyzlejohhanxubdtm5forqkvl3a]

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

resource_id = ocid1.autoscalingconfiguration.oc1.ap-mumbai-1.aaaaaaaaivm5mllzyc5hwzqezzcyo3l4nfyzlejohhanxubdtm5forqkvl3a
resource_name = steampipetest3714
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "cool_down_in_seconds": 300,
    "display_name": "steampipetest3714",
    "freeform_tags": {
      "Department": "Finance"
    },
    "id": "ocid1.autoscalingconfiguration.oc1.ap-mumbai-1.aaaaaaaaivm5mllzyc5hwzqezzcyo3l4nfyzlejohhanxubdtm5forqkvl3a",
    "is_enabled": true
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "cool_down_in_seconds": 300,
    "display_name": "steampipetest3714",
    "freeform_tags": {
      "Department": "Finance"
    },
    "id": "ocid1.autoscalingconfiguration.oc1.ap-mumbai-1.aaaaaaaaivm5mllzyc5hwzqezzcyo3l4nfyzlejohhanxubdtm5forqkvl3a",
    "is_enabled": true
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest3714"
  }
]
✔ PASSED

POSTTEST: tests/oci_autoscaling_auto_scaling_configuration

TEARDOWN: tests/oci_autoscaling_auto_scaling_configuration

SUMMARY:

1/1 passed.

============================================================================================================================================================

@ ~/steam-pipe/oci/oci-test (issue-214) ⏩  ./tint.js oci_dns_zone
Test names: [ 'tests/oci_dns_zone' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_dns_zone []

PRETEST: tests/oci_dns_zone

TEST: tests/oci_dns_zone
Running terraform
oci_dns_zone.named_test_resource: Creating...
oci_dns_zone.named_test_resource: Creation complete after 9s [id=ocid1.dns-zone.oc1..af67deee703c46918e70f93b7de01059]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = ocid1.dns-zone.oc1..af67deee703c46918e70f93b7de01059
resource_name = turbot.com
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.dns-zone.oc1..af67deee703c46918e70f93b7de01059",
    "lifecycle_state": "ACTIVE",
    "name": "turbot.com"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.dns-zone.oc1..af67deee703c46918e70f93b7de01059",
    "lifecycle_state": "ACTIVE",
    "name": "turbot.com"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "turbot.com"
  }
]
✔ PASSED

POSTTEST: tests/oci_dns_zone

TEARDOWN: tests/oci_dns_zone

SUMMARY:

1/1 passed.

==========================================================================================================================================================================

Test names: [ 'tests/oci_kms_key' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_kms_key []

PRETEST: tests/oci_kms_key

TEST: tests/oci_kms_key
Running terraform
oci_kms_vault.named_test_resource: Creating...
oci_kms_vault.named_test_resource: Still creating... [10s elapsed]
oci_kms_vault.named_test_resource: Still creating... [20s elapsed]
oci_kms_vault.named_test_resource: Still creating... [30s elapsed]
oci_kms_vault.named_test_resource: Still creating... [40s elapsed]
oci_kms_vault.named_test_resource: Still creating... [50s elapsed]
oci_kms_vault.named_test_resource: Still creating... [1m0s elapsed]
oci_kms_vault.named_test_resource: Still creating... [1m10s elapsed]
oci_kms_vault.named_test_resource: Still creating... [1m20s elapsed]
oci_kms_vault.named_test_resource: Still creating... [1m30s elapsed]
oci_kms_vault.named_test_resource: Creation complete after 1m37s [id=ocid1.vault.oc1.ap-mumbai-1.crqruee2aabm6.abrg6ljrrqqtpqp2cgsqy6ruy27dapsgzp6kcrv47tnvckcdlfl2k2fbw6ba]
oci_kms_key.named_test_resource: Creating...
oci_kms_key.named_test_resource: Still creating... [10s elapsed]
oci_kms_key.named_test_resource: Still creating... [20s elapsed]
oci_kms_key.named_test_resource: Still creating... [30s elapsed]
oci_kms_key.named_test_resource: Still creating... [40s elapsed]
oci_kms_key.named_test_resource: Still creating... [50s elapsed]
oci_kms_key.named_test_resource: Creation complete after 56s [id=ocid1.key.oc1.ap-mumbai-1.crqruee2aabm6.abrg6ljrtwwlbcfzsycw5o7k4wrq4eyt6n6haj4pkubmes2gma3zyurakqkq]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

region = ap-mumbai-1
resource_id = ocid1.key.oc1.ap-mumbai-1.crqruee2aabm6.abrg6ljrtwwlbcfzsycw5o7k4wrq4eyt6n6haj4pkubmes2gma3zyurakqkq
resource_name = steampipetest8313
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.key.oc1.ap-mumbai-1.crqruee2aabm6.abrg6ljrtwwlbcfzsycw5o7k4wrq4eyt6n6haj4pkubmes2gma3zyurakqkq",
    "lifecycle_state": "ENABLED",
    "name": "steampipetest8313"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "ap-mumbai-1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest8313"
  }
]
✔ PASSED

POSTTEST: tests/oci_kms_key

TEARDOWN: tests/oci_kms_key

SUMMARY:

1/1 passed.

==========================================================================================================================================================

Test names: [ 'tests/oci_functions_application' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_functions_application []

PRETEST: tests/oci_functions_application

TEST: tests/oci_functions_application
Running terraform
oci_core_vcn.named_test_resource: Creating...
oci_core_vcn.named_test_resource: Creation complete after 1s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaafdnlw4bxm6uwkgrffy4oynlwbf6t24cncvognyhso62q]
oci_core_subnet.named_test_resource: Creating...
oci_core_subnet.named_test_resource: Creation complete after 2s [id=ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaark3htcd2xmki54u4o2645ps6sh2fh3q25oju4pi2zz5d7zyjvnoq]
oci_functions_application.test_application: Creating...
oci_functions_application.test_application: Creation complete after 1s [id=ocid1.fnapp.oc1.ap-mumbai-1.aaaaaaaarm6zsy3duzow3valgezhzemjycvvtrd4wkth3elcznh7ecvtl5ua]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

display_name = steampipetest398
freeform_tags = {
  "Department" = "Finance"
}
region = ap-mumbai-1
resource_id = ocid1.fnapp.oc1.ap-mumbai-1.aaaaaaaarm6zsy3duzow3valgezhzemjycvvtrd4wkth3elcznh7ecvtl5ua
resource_name = steampipetest398
subnet_id = ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaark3htcd2xmki54u4o2645ps6sh2fh3q25oju4pi2zz5d7zyjvnoq
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "display_name": "steampipetest398",
    "freeform_tags": {
      "Department": "Finance"
    },
    "id": "ocid1.fnapp.oc1.ap-mumbai-1.aaaaaaaarm6zsy3duzow3valgezhzemjycvvtrd4wkth3elcznh7ecvtl5ua",
    "lifecycle_state": "ACTIVE",
    "subnet_ids": [
      "ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaark3htcd2xmki54u4o2645ps6sh2fh3q25oju4pi2zz5d7zyjvnoq"
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest398",
    "id": "ocid1.fnapp.oc1.ap-mumbai-1.aaaaaaaarm6zsy3duzow3valgezhzemjycvvtrd4wkth3elcznh7ecvtl5ua",
    "lifecycle_state": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "ap-mumbai-1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest398"
  }
]
✔ PASSED

POSTTEST: tests/oci_functions_application

TEARDOWN: tests/oci_functions_application

SUMMARY:

1/1 passed.

============================================================================================================================================================

Test names: [ 'tests/oci_mysql_channel' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_mysql_channel []

PRETEST: tests/oci_mysql_channel

TEST: tests/oci_mysql_channel
Running terraform
oci_core_vcn.named_test_resource: Creating...
oci_core_vcn.named_test_resource: Creation complete after 2s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaazhlatu7zjcjsryzujax3hms73nqledsbbgimru6oxz5a]
oci_core_subnet.named_test_resource: Creating...
oci_core_subnet.named_test_resource: Creation complete after 2s [id=ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaacwkkussekfxm4uaxzg73paytjtfoyagbyoknth6ytmadz6ryrina]
oci_mysql_mysql_db_system.named_test_resource: Creating...
oci_mysql_mysql_db_system.named_test_resource: Still creating... [10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [1m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [2m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [3m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [4m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [5m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [6m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m40s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [7m50s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [8m0s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [8m10s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [8m20s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Still creating... [8m30s elapsed]
oci_mysql_mysql_db_system.named_test_resource: Creation complete after 8m34s [id=ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaabepl6wsto6jgtntnbqah4hq4d67oaxjlb6sfmckqc32jrvg665ca]
oci_mysql_channel.named_test_resource: Creating...
oci_mysql_channel.named_test_resource: Still creating... [10s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [20s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [30s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [40s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [50s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [1m0s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [1m10s elapsed]
oci_mysql_channel.named_test_resource: Still creating... [1m20s elapsed]
oci_mysql_channel.named_test_resource: Creation complete after 1m25s [id=ocid1.mysqlchannel.oc1.ap-mumbai-1.aaaaaaaarjuvyf6xsbq5ucqnhc66yc5wqx3iex27hdiahfqbnzsrz3r5kefq]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

description = steampipetest7619
region = ap-mumbai-1
resource_id = ocid1.mysqlchannel.oc1.ap-mumbai-1.aaaaaaaarjuvyf6xsbq5ucqnhc66yc5wqx3iex27hdiahfqbnzsrz3r5kefq
resource_name = steampipetest7619
state = NEEDS_ATTENTION
target = [
  {
    "applier_username" = "admin"
    "channel_name" = "replication_channel"
    "db_system_id" = "ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaabepl6wsto6jgtntnbqah4hq4d67oaxjlb6sfmckqc32jrvg665ca"
    "target_type" = "DBSYSTEM"
  },
]
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq
time_created = 2021-08-16 12:17:23.401 +0000 UTC

Running SQL query: test-get-query.sql

[
  {
    "description": "steampipetest7619",
    "display_name": "steampipetest7619",
    "freeform_tags": {
      "name": "steampipetest7619"
    },
    "id": "ocid1.mysqlchannel.oc1.ap-mumbai-1.aaaaaaaarjuvyf6xsbq5ucqnhc66yc5wqx3iex27hdiahfqbnzsrz3r5kefq",
    "is_enabled": true,
    "lifecycle_state": "NEEDS_ATTENTION"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest7619",
    "freeform_tags": {
      "name": "steampipetest7619"
    },
    "id": "ocid1.mysqlchannel.oc1.ap-mumbai-1.aaaaaaaarjuvyf6xsbq5ucqnhc66yc5wqx3iex27hdiahfqbnzsrz3r5kefq",
    "is_enabled": true,
    "lifecycle_state": "NEEDS_ATTENTION"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "ap-mumbai-1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest7619"
  }
]
✔ PASSED

POSTTEST: tests/oci_mysql_channel

TEARDOWN: tests/oci_mysql_channel

SUMMARY:

1/1 passed.

========================================================================================================================

Test names: [ 'tests/oci_core_volume' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_volume []

PRETEST: tests/oci_core_volume

TEST: tests/oci_core_volume
Running terraform
oci_core_volume.test_volume: Creating...
oci_core_volume.test_volume: Creation complete after 8s [id=ocid1.volume.oc1.ap-mumbai-1.abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

freeform_tags = {
  "Name" = "steampipetest2661"
}
resource_id = ocid1.volume.oc1.ap-mumbai-1.abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.volume.oc1.ap-mumbai-1.abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za",
    "is_auto_tune_enabled": false,
    "is_hydrated": true,
    "lifecycle_state": "AVAILABLE",
    "size_in_gbs": 50
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za",
    "id": "ocid1.volume.oc1.ap-mumbai-1.abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za",
    "is_auto_tune_enabled": false,
    "is_hydrated": true,
    "lifecycle_state": "AVAILABLE",
    "size_in_gbs": 50
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "abrg6ljrcynuvdz5h7un36naplpcdhkumqjrffhrghfyktvoo6stoj66d6za"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_volume

TEARDOWN: tests/oci_core_volume

SUMMARY:

1/1 passed.

================================================================================================================================================

Test names: [ 'tests/oci_core_drg' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_drg []

PRETEST: tests/oci_core_drg

TEST: tests/oci_core_drg
Running terraform
oci_core_drg.named_test_resource: Creating...
oci_core_drg.named_test_resource: Still creating... [10s elapsed]
oci_core_drg.named_test_resource: Creation complete after 10s [id=ocid1.drg.oc1.ap-mumbai-1.aaaaaaaa4plmvl5cag2vmcodghqixayc5ejuxuquauiomcdcqf3piqtyddlq]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = ocid1.drg.oc1.ap-mumbai-1.aaaaaaaa4plmvl5cag2vmcodghqixayc5ejuxuquauiomcdcqf3piqtyddlq
resource_name = steampipetest5384
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "display_name": "steampipetest5384",
    "freeform_tags": {
      "Name": "steampipetest5384"
    },
    "id": "ocid1.drg.oc1.ap-mumbai-1.aaaaaaaa4plmvl5cag2vmcodghqixayc5ejuxuquauiomcdcqf3piqtyddlq",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest5384",
    "freeform_tags": {
      "Name": "steampipetest5384"
    },
    "id": "ocid1.drg.oc1.ap-mumbai-1.aaaaaaaa4plmvl5cag2vmcodghqixayc5ejuxuquauiomcdcqf3piqtyddlq",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest5384"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_drg

TEARDOWN: tests/oci_core_drg

SUMMARY:

1/1 passed.

==========================================================================================================

Test names: [ 'tests/oci_core_internet_gateway' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_internet_gateway []

PRETEST: tests/oci_core_internet_gateway

TEST: tests/oci_core_internet_gateway
Running terraform
oci_core_vcn.test_vcn: Creating...
oci_core_vcn.test_vcn: Creation complete after 1s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaaqwuopavkilp4txcll5nm33c6no74voor2vw7bsci5a7q]
oci_core_internet_gateway.named_test_resource: Creating...
oci_core_internet_gateway.named_test_resource: Creation complete after 1s [id=ocid1.internetgateway.oc1.ap-mumbai-1.aaaaaaaajuldvfhzszhepj4xxhbejbraantfkjnlti6olg4m3kqtqrglubyq]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

display_name = steampipetest4302
freeform_tags = {
  "Department" = "Finance"
}
resource_id = ocid1.internetgateway.oc1.ap-mumbai-1.aaaaaaaajuldvfhzszhepj4xxhbejbraantfkjnlti6olg4m3kqtqrglubyq
resource_name = steampipetest4302
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "display_name": "steampipetest4302",
    "id": "ocid1.internetgateway.oc1.ap-mumbai-1.aaaaaaaajuldvfhzszhepj4xxhbejbraantfkjnlti6olg4m3kqtqrglubyq",
    "is_enabled": true,
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest4302",
    "id": "ocid1.internetgateway.oc1.ap-mumbai-1.aaaaaaaajuldvfhzszhepj4xxhbejbraantfkjnlti6olg4m3kqtqrglubyq",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest4302"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_internet_gateway

TEARDOWN: tests/oci_core_internet_gateway

SUMMARY:

1/1 passed.

===============================================================================================================================================

Test names: [ 'tests/oci_dns_rrset' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_dns_rrset []

PRETEST: tests/oci_dns_rrset

TEST: tests/oci_dns_rrset
Running terraform
oci_dns_zone.named_test_resource: Creating...
oci_dns_zone.named_test_resource: Creation complete after 8s [id=ocid1.dns-zone.oc1..daf436957aa144e4aab31b8c5ac89c4f]
oci_dns_rrset.named_test_resource: Creating...
oci_dns_rrset.named_test_resource: Still creating... [10s elapsed]
oci_dns_rrset.named_test_resource: Creation complete after 16s [id=zoneNameOrId/steampipetest.com/domain/test/rtype/NS]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

domain = steampipetest.com
rtype = NS
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-list-query.sql

[
  {
    "domain": "steampipetest.com",
    "is_protected": true,
    "rtype": "NS",
    "ttl": "86400"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest.com"
  }
]
✔ PASSED

POSTTEST: tests/oci_dns_rrset

TEARDOWN: tests/oci_dns_rrset

SUMMARY:

1/1 passed.

====================================================================================================================================================================================

Test names: [ 'tests/oci_cloud_guard_responder_recipe' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_cloud_guard_responder_recipe []

PRETEST: tests/oci_cloud_guard_responder_recipe

TEST: tests/oci_cloud_guard_responder_recipe
Running terraform
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard responder-recipe list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --all --output json > /private/var/folders/5q/jqv70bxs7g73gwgv5tvl80l40000gn/T/tests/oci_cloud_guard_responder_recipe/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 1s [id=17644876121559096]
data.local_file.input: Refreshing state...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq
resource_name = OCI Responder Recipe
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Responder Recipe"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Responder Recipe"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "OCI Responder Recipe"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_responder_recipe

TEARDOWN: tests/oci_cloud_guard_responder_recipe

SUMMARY:

1/1 passed.


====================================================================================================================================================================================

Test names: [ 'tests/oci_cloud_guard_configuration' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_cloud_guard_configuration []

PRETEST: tests/oci_cloud_guard_configuration

TEST: tests/oci_cloud_guard_configuration
Running terraform
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard configuration get --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/5q/jqv70bxs7g73gwgv5tvl80l40000gn/T/tests/oci_cloud_guard_configuration/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 1s [id=2734802984813050655]
data.local_file.input: Refreshing state...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

reporting_region = ap-hyderabad-1
self_manage_resources = false
status = ENABLED
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-list-query.sql

[
  {
    "reporting_region": "ap-hyderabad-1",
    "self_manage_resources": false
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_configuration

TEARDOWN: tests/oci_cloud_guard_configuration

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
