### PR TITLE
OCI - extend table oci_core_instances. Closes #293

### DIFF
--- a/docs/tables/oci_core_instance.md
+++ b/docs/tables/oci_core_instance.md
@@ -49,3 +49,20 @@ from
 group by
   shape;
 ```
+
+### List instances with shape configuration details
+
+```sql
+select
+  display_name,
+  shape_config_max_vnic_attachments,
+  shape_config_memory_in_gbs,
+  shape_config_networking_bandwidth_in_gbps,
+  shape_config_ocpus,
+  shape_config_baseline_ocpu_utilization,
+  shape_config_gpus,
+  shape_config_local_disks,
+  shape_config_local_disks_total_size_in_gbs
+from
+  oci_core_instance;
+```

--- a/oci/table_oci_core_instance.go
+++ b/oci/table_oci_core_instance.go
@@ -78,15 +78,63 @@ func tableCoreInstance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "shape",
+				Description: "The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "shape_config_baseline_ocpu_utilization",
+				Description: "The baseline OCPU utilization for a subcore burstable VM instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ShapeConfig.BaselineOcpuUtilization"),
+			},
+			{
+				Name:        "shape_config_gpus",
+				Description: "The number of GPUs available to the instance.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("ShapeConfig.Gpus"),
+			},
+			{
+				Name:        "shape_config_local_disks",
+				Description: "The number of local disks available to the instance.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("ShapeConfig.LocalDisks"),
+			},
+			{
+				Name:        "shape_config_local_disks_total_size_in_gbs",
+				Description: "The aggregate size of all local disks, in gigabytes.",
+				Type:        proto.ColumnType_DOUBLE,
+				Transform:   transform.FromField("ShapeConfig.LocalDisksTotalSizeInGBs"),
+			},
+			{
+				Name:        "shape_config_max_vnic_attachments",
+				Description: "The maximum number of VNIC attachments for the instance.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("ShapeConfig.MaxVnicAttachments"),
+			},
+			{
+				Name:        "shape_config_memory_in_gbs",
+				Description: "The total amount of memory available to the instance, in gigabytes.",
+				Type:        proto.ColumnType_DOUBLE,
+				Transform:   transform.FromField("ShapeConfig.MemoryInGBs"),
+			},
+			{
+				Name:        "shape_config_networking_bandwidth_in_gbps",
+				Description: "The networking bandwidth available to the instance, in gigabits per second.",
+				Type:        proto.ColumnType_DOUBLE,
+				Transform:   transform.FromField("ShapeConfig.NetworkingBandwidthInGbps"),
+			},
+			{
+				Name:        "shape_config_ocpus",
+				Description: "The total number of OCPUs available to the instance.",
+				Type:        proto.ColumnType_DOUBLE,
+				Transform:   transform.FromField("ShapeConfig.Ocpus"),
+			},
+			{
 				Name:        "time_maintenance_reboot_due",
 				Description: "The date and time the instance is expected to be stopped/started. After that time if instance hasn't been rebooted, Oracle will reboot the instance within 24 hours of the due time.",
 				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("TimeMaintenanceRebootDue.time"),
-			},
-			{
-				Name:        "shape",
-				Description: "The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance.",
-				Type:        proto.ColumnType_STRING,
 			},
 
 			// json fields


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro oci-test % ./tint.js oci_core_instance
Test names: [ 'tests/oci_core_instance' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_instance []

PRETEST: tests/oci_core_instance

TEST: tests/oci_core_instance
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.image will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "image"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_core_instance/terraform/test/image.json"
      + id             = (known after apply)
    }

  # data.local_file.instance will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "instance"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_core_instance/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

  # null_resource.test_image will be created
  + resource "null_resource" "test_image" {
      + id = (known after apply)
    }

  # oci_core_subnet.named_test_resource will be created
  + resource "oci_core_subnet" "named_test_resource" {
      + availability_domain        = (known after apply)
      + cidr_block                 = "10.0.0.0/16"
      + compartment_id             = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
      + defined_tags               = (known after apply)
      + dhcp_options_id            = (known after apply)
      + display_name               = "steampipetest2780"
      + dns_label                  = (known after apply)
      + freeform_tags              = {
          + "Name" = "steampipetest2780"
        }
      + id                         = (known after apply)
      + ipv6cidr_block             = (known after apply)
      + ipv6virtual_router_ip      = (known after apply)
      + prohibit_internet_ingress  = (known after apply)
      + prohibit_public_ip_on_vnic = (known after apply)
      + route_table_id             = (known after apply)
      + security_list_ids          = (known after apply)
      + state                      = (known after apply)
      + subnet_domain_name         = (known after apply)
      + time_created               = (known after apply)
      + vcn_id                     = (known after apply)
      + virtual_router_ip          = (known after apply)
      + virtual_router_mac         = (known after apply)
    }

  # oci_core_vcn.named_test_resource will be created
  + resource "oci_core_vcn" "named_test_resource" {
      + cidr_block               = "10.0.0.0/16"
      + cidr_blocks              = (known after apply)
      + compartment_id           = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
      + default_dhcp_options_id  = (known after apply)
      + default_route_table_id   = (known after apply)
      + default_security_list_id = (known after apply)
      + defined_tags             = (known after apply)
      + display_name             = "steampipetest2780"
      + dns_label                = (known after apply)
      + freeform_tags            = (known after apply)
      + id                       = (known after apply)
      + ipv6cidr_blocks          = (known after apply)
      + is_ipv6enabled           = (known after apply)
      + state                    = (known after apply)
      + time_created             = (known after apply)
      + vcn_domain_name          = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + availability_domain = (known after apply)
  + lifecycle_state     = (known after apply)
  + resource_id         = (known after apply)
  + resource_name       = (known after apply)
  + shape               = (known after apply)
  + tenancy_ocid        = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
oci_core_vcn.named_test_resource: Creating...
oci_core_vcn.named_test_resource: Creation complete after 1s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaa5rvzornqb6rpvx7r6sumwarpb2cde4xp4pz5fqqh4uia]
oci_core_subnet.named_test_resource: Creating...
oci_core_subnet.named_test_resource: Creation complete after 2s [id=ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa7bpum6r6rscbf3d3mh3dsvy76c6qx3gd2msoqivoouc2yakaqmna]
null_resource.test_image: Creating...
null_resource.test_image: Provisioning with 'local-exec'...
null_resource.test_image (local-exec): Executing: ["/bin/sh" "-c" "oci compute image list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --all --display-name Oracle-Autonomous-Linux-7.9-2021.05-0 --output json > /private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_core_instance/terraform/test/image.json"]
null_resource.test_image: Creation complete after 2s [id=4888478002577335930]
data.local_file.image: Reading...
data.local_file.image: Read complete after 0s [id=af3f36599699397c30d26437f50259c029bbd3bf]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci compute instance launch --availability-domain TvRS:AP-MUMBAI-1-AD-1 --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --shape VM.Standard2.1 --subnet-id ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa7bpum6r6rscbf3d3mh3dsvy76c6qx3gd2msoqivoouc2yakaqmna --image-id ocid1.image.oc1.ap-mumbai-1.aaaaaaaahkwyrvis5iyrezoric5zmrld4r6xhilonvduzhas25vmyffhirxq --output json > /private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_core_instance/terraform/test/output.json"]
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "sleep 150"]
null_resource.named_test_resource: Still creating... [10s elapsed]
null_resource.named_test_resource: Still creating... [20s elapsed]
null_resource.named_test_resource: Still creating... [30s elapsed]
null_resource.named_test_resource: Still creating... [40s elapsed]
null_resource.named_test_resource: Still creating... [50s elapsed]
null_resource.named_test_resource: Still creating... [1m0s elapsed]
null_resource.named_test_resource: Still creating... [1m10s elapsed]
null_resource.named_test_resource: Still creating... [1m20s elapsed]
null_resource.named_test_resource: Still creating... [1m30s elapsed]
null_resource.named_test_resource: Still creating... [1m40s elapsed]
null_resource.named_test_resource: Still creating... [1m50s elapsed]
null_resource.named_test_resource: Still creating... [2m0s elapsed]
null_resource.named_test_resource: Still creating... [2m10s elapsed]
null_resource.named_test_resource: Still creating... [2m20s elapsed]
null_resource.named_test_resource: Still creating... [2m30s elapsed]
null_resource.named_test_resource: Creation complete after 2m32s [id=732854720284290991]
data.local_file.instance: Reading...
data.local_file.instance: Read complete after 0s [id=ad4bd67ddb5968e1950de1083e7ed45d6115ec33]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

availability_domain = "TvRS:AP-MUMBAI-1-AD-1"
lifecycle_state = "PROVISIONING"
resource_id = "ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexactkfvltftaq3fkqbuupuyxfqdd3jb2ttgkq3deua25mrq"
resource_name = "instance20210825095622"
shape = "VM.Standard2.1"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
    "display_name": "instance20210825095622",
    "id": "ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexactkfvltftaq3fkqbuupuyxfqdd3jb2ttgkq3deua25mrq",
    "shape": "VM.Standard2.1"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
    "display_name": "instance20210825095622",
    "id": "ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexactkfvltftaq3fkqbuupuyxfqdd3jb2ttgkq3deua25mrq",
    "shape": "VM.Standard2.1"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "instance20210825095622"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_instance
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.destroy_test_resource will be created
  + resource "null_resource" "destroy_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
null_resource.destroy_test_resource: Creating...
null_resource.destroy_test_resource: Provisioning with 'local-exec'...
null_resource.destroy_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci compute instance terminate --instance-id ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexactkfvltftaq3fkqbuupuyxfqdd3jb2ttgkq3deua25mrq --force"]
null_resource.destroy_test_resource: Creation complete after 2s [id=3808055852574111681]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

TEARDOWN: tests/oci_core_instance


SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  display_name,
  id,
  time_created,
  lifecycle_state as state,
  shape,
  region
from
  oci_core_instance;
+-----------------------------+---------------------------------------------------------------------------------------------+---------------------+---------+---------------------+-------------+
| display_name                | id                                                                                          | time_created        | state   | shape               | region      |
+-----------------------------+---------------------------------------------------------------------------------------------+---------------------+---------+---------------------+-------------+
| test-instance-20210825-1329 | ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexacoiy6gxa6jhur2arvhf7ar7pblyhqcm6rko2myf67tdba | 2021-08-25 08:01:20 | RUNNING | VM.Standard.E4.Flex | ap-mumbai-1 |
+-----------------------------+---------------------------------------------------------------------------------------------+---------------------+---------+---------------------+-------------+
> select
  shape,
  count(shape) as count
from
  oci_core_instance
group by
  shape;
+---------------------+-------+
| shape               | count |
+---------------------+-------+
| VM.Standard.E4.Flex | 1     |
+---------------------+-------+
> select
  inst.display_name,
  inst.id,
  inst.shape,
  inst.region,
  comp.name as compartment_name
from
  oci_core_instance inst
  inner join
    oci_identity_compartment comp
    on (inst.compartment_id = comp.id)
order by
  comp.name,
  inst.region,
  inst.shape;
+--------------+----+-------+--------+------------------+
| display_name | id | shape | region | compartment_name |
+--------------+----+-------+--------+------------------+
+--------------+----+-------+--------+------------------+
> select
  display_name,
  shape_config_max_vnic_attachments,
  shape_config_memory_in_gbs,
  shape_config_networking_bandwidth_in_gbps,
  shape_config_ocpus,
  shape_config_baseline_ocpu_utilization,
  shape_config_gpus,
  shape_config_local_disks,
  shape_config_local_disks_total_size_in_gbs
from
  oci_core_instance;
+-----------------------------+-----------------------------------+----------------------------+-------------------------------------------+--------------------+----------------------------------------+--
| display_name                | shape_config_max_vnic_attachments | shape_config_memory_in_gbs | shape_config_networking_bandwidth_in_gbps | shape_config_ocpus | shape_config_baseline_ocpu_utilization | s
+-----------------------------+-----------------------------------+----------------------------+-------------------------------------------+--------------------+----------------------------------------+--
| test-instance-20210825-1329 | 2                                 | 16                         | 1                                         | 1                  |                                        | 0
+-----------------------------+-----------------------------------+----------------------------+-------------------------------------------+--------------------+----------------------------------------+--
> 
```
</details>
