### PR TITLE
Handle 'InvalidParameter', '400' and '404' errors in table_oci_logging_log_group and table_oci_core_nat_gateway. Closes #326

### DIFF
--- a/docs/tables/oci_logging_log_group.md
+++ b/docs/tables/oci_logging_log_group.md
@@ -13,7 +13,7 @@ select
   lifecycle_state,
   time_created
 from
-  oci_new.oci_logging_log_group;
+  oci_logging_log_group;
 ```
 
 
@@ -26,7 +26,7 @@ select
   lifecycle_state as state,
   time_created
 from
-  oci_new.oci_logging_log_group
+  oci_logging_log_group
 where
   lifecycle_state = 'INACTIVE';
 ```

--- a/oci/table_oci_core_nat_gateway.go
+++ b/oci/table_oci_core_nat_gateway.go
@@ -19,8 +19,9 @@ func tableCoreNatGateway(_ context.Context) *plugin.Table {
 		Name:        "oci_core_nat_gateway",
 		Description: "OCI Core Nat Gateway",
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.SingleColumn("id"),
-			Hydrate:    getCoreNatGateway,
+			KeyColumns:        plugin.SingleColumn("id"),
+			ShouldIgnoreError: isNotFoundError([]string{"400", "404"}),
+			Hydrate:           getCoreNatGateway,
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listCoreNatGateways,

--- a/oci/table_oci_logging_log_group.go
+++ b/oci/table_oci_logging_log_group.go
@@ -167,6 +167,13 @@ func listLoggingLogGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	for pagesLeft {
 		response, err := session.LoggingManagementClient.ListLogGroups(ctx, request)
 		if err != nil {
+			plugin.Logger(ctx).Error("listLoggingLogGroups", "error_ListLogGroups", err)
+			if ociErr, ok := err.(common.ServiceError); ok {
+				if ociErr.GetCode() == "InvalidParameter" {
+					return logging.ListLogGroupsResponse{}, nil
+				}
+			}
+			
 			return nil, err
 		}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro oci-test % ./tint.js oci_logging_log_group
Test names: [ 'tests/oci_logging_log_group' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_logging_log_group []

PRETEST: tests/oci_logging_log_group

TEST: tests/oci_logging_log_group
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oci_logging_log_group.test_log_group will be created
  + resource "oci_logging_log_group" "test_log_group" {
      + compartment_id     = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
      + defined_tags       = (known after apply)
      + description        = "steampipetest3047"
      + display_name       = "steampipetest3047"
      + freeform_tags      = {
          + "Name" = "steampipetest3047"
        }
      + id                 = (known after apply)
      + state              = (known after apply)
      + time_created       = (known after apply)
      + time_last_modified = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + display_name  = "steampipetest3047"
  + freeform_tags = {
      + "Name" = "steampipetest3047"
    }
  + region        = "ap-mumbai-1"
  + resource_id   = (known after apply)
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
oci_logging_log_group.test_log_group: Creating...
oci_logging_log_group.test_log_group: Creation complete after 2s [id=ocid1.loggroup.oc1.ap-mumbai-1.amaaaaaa6igdexaa66kugwsgw2sb2wsewgjwnqw2heza7cbf4weplibmxpsq]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

display_name = "steampipetest3047"
freeform_tags = tomap({
  "Name" = "steampipetest3047"
})
region = "ap-mumbai-1"
resource_id = "ocid1.loggroup.oc1.ap-mumbai-1.amaaaaaa6igdexaa66kugwsgw2sb2wsewgjwnqw2heza7cbf4weplibmxpsq"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "description": "steampipetest3047",
    "display_name": "steampipetest3047",
    "id": "ocid1.loggroup.oc1.ap-mumbai-1.amaaaaaa6igdexaa66kugwsgw2sb2wsewgjwnqw2heza7cbf4weplibmxpsq",
    "lifecycle_state": "ACTIVE",
    "title": "steampipetest3047"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest3047",
    "freeform_tags": {
      "Name": "steampipetest3047"
    },
    "id": "ocid1.loggroup.oc1.ap-mumbai-1.amaaaaaa6igdexaa66kugwsgw2sb2wsewgjwnqw2heza7cbf4weplibmxpsq"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "ap-mumbai-1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest3047"
  }
]
✔ PASSED

POSTTEST: tests/oci_logging_log_group

TEARDOWN: tests/oci_logging_log_group

SUMMARY:

1/1 passed.

arnab@turbotindias-MacBook-Pro oci-test % ./tint.js oci_core_nat_gateway
Test names: [ 'tests/oci_core_nat_gateway' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_nat_gateway []

PRETEST: tests/oci_core_nat_gateway

TEST: tests/oci_core_nat_gateway
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oci_core_nat_gateway.named_test_resource will be created
  + resource "oci_core_nat_gateway" "named_test_resource" {
      + block_traffic  = true
      + compartment_id = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
      + defined_tags   = (known after apply)
      + display_name   = "steampipetest6041"
      + freeform_tags  = {
          + "Name" = "steampipetest6041"
        }
      + id             = (known after apply)
      + nat_ip         = (known after apply)
      + public_ip_id   = (known after apply)
      + state          = (known after apply)
      + time_created   = (known after apply)
      + vcn_id         = (known after apply)
    }

  # oci_core_vcn.named_test_resource will be created
  + resource "oci_core_vcn" "named_test_resource" {
      + cidr_block               = "10.0.0.0/16"
      + cidr_blocks              = (known after apply)
      + compartment_id           = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
      + default_dhcp_options_id  = (known after apply)
      + default_route_table_id   = (known after apply)
      + default_security_list_id = (known after apply)
      + defined_tags             = (known after apply)
      + display_name             = "steampipetest6041"
      + dns_label                = (known after apply)
      + freeform_tags            = (known after apply)
      + id                       = (known after apply)
      + ipv6cidr_blocks          = (known after apply)
      + is_ipv6enabled           = (known after apply)
      + state                    = (known after apply)
      + time_created             = (known after apply)
      + vcn_domain_name          = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + display_name  = "steampipetest6041"
  + freeform_tags = {
      + "Name" = "steampipetest6041"
    }
  + resource_id   = (known after apply)
  + resource_name = "steampipetest6041"
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
  + time_created  = (known after apply)
  + vcn_id        = (known after apply)
oci_core_vcn.named_test_resource: Creating...
oci_core_vcn.named_test_resource: Creation complete after 1s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaapwnstn5idh4hcaphdpethyyors2w6ngb25l5nc3s26na]
oci_core_nat_gateway.named_test_resource: Creating...
oci_core_nat_gateway.named_test_resource: Creation complete after 2s [id=ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaarlr6yqdaoedgdz5e6tq6fxxbfsok5ofczp7ggm3uyv2itisgd5dq]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

display_name = "steampipetest6041"
freeform_tags = tomap({
  "Name" = "steampipetest6041"
})
resource_id = "ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaarlr6yqdaoedgdz5e6tq6fxxbfsok5ofczp7ggm3uyv2itisgd5dq"
resource_name = "steampipetest6041"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
time_created = "2021-11-17 12:16:18.189 +0000 UTC"
vcn_id = "ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaapwnstn5idh4hcaphdpethyyors2w6ngb25l5nc3s26na"

Running SQL query: test-get-query.sql

[
  {
    "display_name": "steampipetest6041",
    "freeform_tags": {
      "Name": "steampipetest6041"
    },
    "id": "ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaarlr6yqdaoedgdz5e6tq6fxxbfsok5ofczp7ggm3uyv2itisgd5dq",
    "vcn_id": "ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaapwnstn5idh4hcaphdpethyyors2w6ngb25l5nc3s26na"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest6041",
    "freeform_tags": {
      "Name": "steampipetest6041"
    },
    "id": "ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaarlr6yqdaoedgdz5e6tq6fxxbfsok5ofczp7ggm3uyv2itisgd5dq",
    "vcn_id": "ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaapwnstn5idh4hcaphdpethyyors2w6ngb25l5nc3s26na"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest6041"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_nat_gateway

TEARDOWN: tests/oci_core_nat_gateway

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id as log_group_id,
  display_name,
  lifecycle_state,
  time_created
from
  oci_logging_log_group;
+------------------------------------------------------------------------------------------------+-----------------+-----------------+----------------------+
| log_group_id                                                                                   | display_name    | lifecycle_state | time_created         |
+------------------------------------------------------------------------------------------------+-----------------+-----------------+----------------------+
| ocid1.loggroup.oc1.ap-mumbai-1.amaaaaaa6igdexaat6klimva7j3un7fa2ee555ndm2aevl4ejcyl6aexosta    | Default_Group   | ACTIVE          | 2021-08-13T09:43:47Z |
| ocid1.loggroup.oc1.ap-hyderabad-1.amaaaaaa6igdexaauumzbitcsjvcv2myrmzc54fa4qctvygshu5m33meaj6a | Default_Group   | ACTIVE          | 2021-07-22T06:48:17Z |
| ocid1.loggroup.oc1.iad.amaaaaaa6igdexaafsd7bd5kuvhnrs7lqg5ddgymd6lbnlwgowjivjl24jlq            | cis-test-by-raj | ACTIVE          | 2021-06-16T11:58:52Z |
| ocid1.loggroup.oc1.iad.amaaaaaa6igdexaa2okabqoeyjyeqw2c5xzytiwisko5m3mijvf4jn43g7dq            | test455         | ACTIVE          | 2021-04-12T13:11:26Z |
+------------------------------------------------------------------------------------------------+-----------------+-----------------+----------------------+
> select
  id as log_group_id,
  display_name,
  lifecycle_state as state,
  time_created
from
  oci_logging_log_group
where
  lifecycle_state = 'INACTIVE';
+--------------+--------------+-------+--------------+
| log_group_id | display_name | state | time_created |
+--------------+--------------+-------+--------------+
+--------------+--------------+-------+--------------+
> select
  display_name,
  id,
  time_created,
  lifecycle_state as state,
  public_ip_id,
  region,
  tags
from
  oci_core_nat_gateway;
+-------------------+-----------------------------------------------------------------------------------------------+----------------------+-----------+----------------------------------------------------
| display_name      | id                                                                                            | time_created         | state     | public_ip_id                                       
+-------------------+-----------------------------------------------------------------------------------------------+----------------------+-----------+----------------------------------------------------
| steampipetest3223 | ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaamgnoge75be6ag6ogzzrq3zne3htcpxvxkqy3vcexc5vvldulsucq | 2021-11-17T12:18:04Z | AVAILABLE | ocid1.publicip.oc1.ap-mumbai-1.aaaaaaaa7glxtcty3cvz
+-------------------+-----------------------------------------------------------------------------------------------+----------------------+-----------+----------------------------------------------------
> select
  display_name,
  id,
  block_traffic
from
  oci_core_nat_gateway
where
  block_traffic;
+-------------------+-----------------------------------------------------------------------------------------------+---------------+
| display_name      | id                                                                                            | block_traffic |
+-------------------+-----------------------------------------------------------------------------------------------+---------------+
| steampipetest3223 | ocid1.natgateway.oc1.ap-mumbai-1.aaaaaaaamgnoge75be6ag6ogzzrq3zne3htcpxvxkqy3vcexc5vvldulsucq | true          |
+-------------------+-----------------------------------------------------------------------------------------------+---------------+
> select
  vcn_id,
  count(*) as nat_gateway_count
from
  oci_core_nat_gateway
group by
  vcn_id;
+----------------------------------------------------------------------------------------+-------------------+
| vcn_id                                                                                 | nat_gateway_count |
+----------------------------------------------------------------------------------------+-------------------+
| ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaa36beprnmeeektaui3toy26ws4f5rvkjlokdu42uweanq | 1                 |
+----------------------------------------------------------------------------------------+-------------------+
```
</details>
