### PR TITLE
Fix integration tests for table oci_cloud_guard_configuration. Closes #322

### DIFF
--- a/oci-test/tests/oci_cloud_guard_configuration/test-list-expected.json
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-list-expected.json
@@ -1,6 +1,6 @@
 [
   {
     "reporting_region": "{{ output.reporting_region.value }}",
-    "self_manage_resources": false
+    "status": "{{ output.status.value }}"
   }
 ]

--- a/oci-test/tests/oci_cloud_guard_configuration/test-list-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-list-query.sql
@@ -1,3 +1,3 @@
-select reporting_region, self_manage_resources
+select reporting_region, status
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}';
+where reporting_region = '{{ output.reporting_region.value }}';

--- a/oci-test/tests/oci_cloud_guard_configuration/test-not-found-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-not-found-query.sql
@@ -1,3 +1,3 @@
-select region
+select reporting_region
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}::dummy';
+where reporting_region = '{{ output.reporting_region.value }}::dummy';

--- a/oci-test/tests/oci_cloud_guard_configuration/test-turbot-query.sql
+++ b/oci-test/tests/oci_cloud_guard_configuration/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select tenant_id
 from oci.oci_cloud_guard_configuration
-where region = '{{ output.reporting_region.value }}';
+where reporting_region = '{{ output.reporting_region.value }}';

--- a/oci-test/tests/oci_cloud_guard_configuration/variables.tf
+++ b/oci-test/tests/oci_cloud_guard_configuration/variables.tf
@@ -51,5 +51,5 @@ output "tenancy_ocid" {
 }
 
 output "status" {
-  value = jsondecode(data.local_file.input.content).data.self-manage-resources
+  value = jsondecode(data.local_file.input.content).data.status
 }

--- a/oci-test/tests/oci_cloud_guard_configuration/variables.tf
+++ b/oci-test/tests/oci_cloud_guard_configuration/variables.tf
@@ -27,21 +27,29 @@ provider "oci" {
   config_file_profile = var.config_file_profile
 }
 
-resource "oci_cloud_guard_cloud_guard_configuration" "named_test_resource" {
-  #Required
-  compartment_id   = var.tenancy_ocid
-  reporting_region = var.region
-  status           = "ENABLED"
+locals {
+  path = "${path.cwd}/output.json"
+}
+
+resource "null_resource" "named_test_resource" {
+  provisioner "local-exec" {
+    command = "oci cloud-guard configuration get --compartment-id ${var.tenancy_ocid} --output json > ${local.path}"
+  }
+}
+
+data "local_file" "input" {
+  depends_on = [null_resource.named_test_resource]
+  filename   = local.path
 }
 
 output "reporting_region" {
-  value = var.region
+  value = jsondecode(data.local_file.input.content).data.reporting-region
 }
 
 output "tenancy_ocid" {
   value = var.tenancy_ocid
 }
 
-output "self_manage_resources" {
-  value = oci_cloud_guard_cloud_guard_configuration.named_test_resource.self_manage_resources
+output "status" {
+  value = jsondecode(data.local_file.input.content).data.self-manage-resources
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro oci-test % ./tint.js oci_cloud_guard_configuration
Test names: [ 'tests/oci_cloud_guard_configuration' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_cloud_guard_configuration []

PRETEST: tests/oci_cloud_guard_configuration

TEST: tests/oci_cloud_guard_configuration
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_cloud_guard_configuration/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + reporting_region = (known after apply)
  + status           = (known after apply)
  + tenancy_ocid     = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard configuration get --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/oci_cloud_guard_configuration/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 4s [id=8971593555130631658]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=606f6f35b022070dccf85db39f08875f36125332]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

reporting_region = "ap-hyderabad-1"
status = "ENABLED"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-list-query.sql

[
  {
    "reporting_region": "ap-hyderabad-1",
    "status": "ENABLED"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_configuration

TEARDOWN: tests/oci_cloud_guard_configuration

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  reporting_region,
  status,
  self_manage_resources
from
  oci_cloud_guard_configuration;
+------------------+---------+-----------------------+
| reporting_region | status  | self_manage_resources |
+------------------+---------+-----------------------+
| ap-hyderabad-1   | ENABLED | false                 |
+------------------+---------+-----------------------+
```
</details>
