### PR TITLE
Added reporting region in service for CloudGuard tables.

### DIFF
--- a/oci-test/tests/oci_cloud_guard_detector_recipe/variables.tf
+++ b/oci-test/tests/oci_cloud_guard_detector_recipe/variables.tf
@@ -27,15 +27,23 @@ provider "oci" {
   config_file_profile = var.config_file_profile
 }
 
-resource "oci_cloud_guard_detector_recipe" "named_test_resource" {
-  #Required
-  compartment_id            = var.tenancy_ocid
-  display_name              = var.resource_name
-  source_detector_recipe_id = oci_cloud_guard_detector_recipe.named_test_resource.id
+locals {
+  path = "${path.cwd}/output.json"
+}
+
+resource "null_resource" "named_test_resource" {
+  provisioner "local-exec" {
+    command = "oci cloud-guard detector-recipe list --compartment-id ${var.tenancy_ocid} --output json > ${local.path}"
+  }
+}
+
+data "local_file" "input" {
+  depends_on = [null_resource.named_test_resource]
+  filename   = local.path
 }
 
 output "resource_name" {
-  value = var.resource_name
+  value = jsondecode(data.local_file.input.content).data.items[0].display-name
 }
 
 output "tenancy_ocid" {
@@ -43,5 +51,5 @@ output "tenancy_ocid" {
 }
 
 output "resource_id" {
-  value = oci_cloud_guard_detector_recipe.named_test_resource.id
+  value = jsondecode(data.local_file.input.content).data.items[0].id
 }

--- a/oci/multi_region.go
+++ b/oci/multi_region.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/oracle/oci-go-sdk/v44/cloudguard"
 	oci_common "github.com/oracle/oci-go-sdk/v44/common"
 	"github.com/oracle/oci-go-sdk/v44/identity"
 	"github.com/turbot/go-kit/helpers"
@@ -354,4 +355,31 @@ func getRegionFromEnvVar() string {
 	}
 
 	return getEnvSettingWithBlankDefault("region")
+}
+
+func getCloudGuardConfiguration(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	cacheKey := "getCloudGuardConfiguration"
+	if cachedData, ok := pluginQueryData.ConnectionManager.Cache.Get(cacheKey); ok {
+		return cachedData.(interface{}), nil
+	}
+
+	// Create Session
+	session, err := cloudGuardService(ctx, d, "")
+	if err != nil {
+		return nil, err
+	}
+
+	request := cloudguard.GetConfigurationRequest{
+		CompartmentId: types.String(session.TenancyID),
+		RequestMetadata: oci_common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+
+	response, err := session.CloudGuardClient.GetConfiguration(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Configuration, nil
 }

--- a/oci/service.go
+++ b/oci/service.go
@@ -790,17 +790,16 @@ func coreVirtualNetworkService(ctx context.Context, d *plugin.QueryData, region 
 }
 
 // cloudGuardService returns the service client for OCI Cloud Guard Service
-func cloudGuardService(ctx context.Context, d *plugin.QueryData) (*session, error) {
+func cloudGuardService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
 	logger := plugin.Logger(ctx)
-	serviceCacheKey := fmt.Sprintf("cloudguard-%s", "region")
+	serviceCacheKey := fmt.Sprintf("cloudguard-%s", region)
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*session), nil
 	}
 
 	// get oci config info
 	ociConfig := GetConfig(d.Connection)
-
-	provider, err := getProvider(ctx, d.ConnectionManager, "", ociConfig)
+	provider, err := getProvider(ctx, d.ConnectionManager, region, ociConfig)
 	if err != nil {
 		logger.Error("cloudGuardService", "getProvider.Error", err)
 		return nil, err
@@ -1277,7 +1276,7 @@ func analyticsService(ctx context.Context, d *plugin.QueryData, region string) (
 	}
 
 	sess := &session{
-		TenancyID:     tenantId,
+		TenancyID:       tenantId,
 		AnalyticsClient: client,
 	}
 

--- a/oci/table_oci_cloud_guard_configuration.go
+++ b/oci/table_oci_cloud_guard_configuration.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"github.com/oracle/oci-go-sdk/v44/cloudguard"
-	oci_common "github.com/oracle/oci-go-sdk/v44/common"
-	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -51,25 +49,14 @@ func tableCloudGuardConfiguration(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listCloudGuardConfigurations(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	// Create Session
-	session, err := cloudGuardService(ctx, d)
+func listCloudGuardConfigurations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	getCloudGuardConfigurationCached := plugin.HydrateFunc(getCloudGuardConfiguration).WithCache()
+	configuration, err := getCloudGuardConfigurationCached(ctx, d, h)
 	if err != nil {
 		return nil, err
 	}
 
-	request := cloudguard.GetConfigurationRequest{
-		CompartmentId: types.String(session.TenancyID),
-		RequestMetadata: oci_common.RequestMetadata{
-			RetryPolicy: getDefaultRetryPolicy(),
-		},
-	}
+	d.StreamListItem(ctx, configuration.(cloudguard.Configuration))
 
-	response, err := session.CloudGuardClient.GetConfiguration(ctx, request)
-	if err != nil {
-		return nil, err
-	}
-	d.StreamListItem(ctx, response.Configuration)
-
-	return nil, err
+	return nil, nil
 }

--- a/oci/table_oci_cloud_guard_detector_recipe.go
+++ b/oci/table_oci_cloud_guard_detector_recipe.go
@@ -158,7 +158,7 @@ func tableCloudGuardDetectorRecipe(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listCloudGuardDetectorRecipes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listCloudGuardDetectorRecipes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Trace("oci.listCloudGuardDetectorRecipes", "Compartment", compartment)
@@ -170,8 +170,17 @@ func listCloudGuardDetectorRecipes(ctx context.Context, d *plugin.QueryData, _ *
 		return nil, nil
 	}
 
+	// fetch reporting region from configuration
+	getCloudGuardConfigurationCached := plugin.HydrateFunc(getCloudGuardConfiguration).WithCache()
+	configuration, err := getCloudGuardConfigurationCached(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+
+	reportingRegion := configuration.(cloudguard.Configuration).ReportingRegion
+
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, *reportingRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -244,8 +253,17 @@ func getCloudGuardDetectorRecipe(ctx context.Context, d *plugin.QueryData, h *pl
 		id = d.KeyColumnQuals["id"].GetStringValue()
 	}
 
+	// fetch reporting region from configuration
+	getCloudGuardConfigurationCached := plugin.HydrateFunc(getCloudGuardConfiguration).WithCache()
+	configuration, err := getCloudGuardConfigurationCached(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+
+	reportingRegion := configuration.(cloudguard.Configuration).ReportingRegion
+
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, *reportingRegion)
 	if err != nil {
 		return nil, err
 	}

--- a/oci/table_oci_cloud_guard_responder_recipe.go
+++ b/oci/table_oci_cloud_guard_responder_recipe.go
@@ -158,7 +158,7 @@ func tableCloudGuardResponderRecipe(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listCloudGuardResponderRecipes(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listCloudGuardResponderRecipes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
 	logger.Debug("oci.listCloudGuardResponderRecipes", "Compartment", compartment)
@@ -170,8 +170,17 @@ func listCloudGuardResponderRecipes(ctx context.Context, d *plugin.QueryData, _ 
 		return nil, nil
 	}
 
+	// fetch reporting region from configuration
+	getCloudGuardConfigurationCached := plugin.HydrateFunc(getCloudGuardConfiguration).WithCache()
+	configuration, err := getCloudGuardConfigurationCached(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+
+	reportingRegion := configuration.(cloudguard.Configuration).ReportingRegion
+
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, *reportingRegion)
 	if err != nil {
 		return nil, err
 	}
@@ -249,8 +258,17 @@ func getCloudGuardResponderRecipe(ctx context.Context, d *plugin.QueryData, h *p
 		return nil, nil
 	}
 
+	// fetch reporting region from configuration
+	getCloudGuardConfigurationCached := plugin.HydrateFunc(getCloudGuardConfiguration).WithCache()
+	configuration, err := getCloudGuardConfigurationCached(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+
+	reportingRegion := configuration.(cloudguard.Configuration).ReportingRegion
+
 	// Create Session
-	session, err := cloudGuardService(ctx, d)
+	session, err := cloudGuardService(ctx, d, *reportingRegion)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/oci_cloud_guard_configuration []

PRETEST: tests/oci_cloud_guard_configuration

TEST: tests/oci_cloud_guard_configuration
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_configuration/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + reporting_region = (known after apply)
  + status           = (known after apply)
  + tenancy_ocid     = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard configuration get --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_configuration/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/.oci/config are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/.oci/config
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/Downloads/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/Downloads/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource: Creation complete after 5s [id=1951368010356860823]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=606f6f35b022070dccf85db39f08875f36125332]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

reporting_region = "ap-hyderabad-1"
status = "ENABLED"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-list-query.sql

[
  {
    "reporting_region": "ap-hyderabad-1",
    "status": "ENABLED"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_configuration

TEARDOWN: tests/oci_cloud_guard_configuration

SUMMARY:

1/1 passed.

SETUP: tests/oci_cloud_guard_detector_recipe []

PRETEST: tests/oci_cloud_guard_detector_recipe

TEST: tests/oci_cloud_guard_detector_recipe
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_detector_recipe/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_id   = (known after apply)
  + resource_name = (known after apply)
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard detector-recipe list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_detector_recipe/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/.oci/config are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/.oci/config
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/Downloads/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/Downloads/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: This operation supports pagination and not all resources were returned.  Re-run using the --all option to auto paginate and list all resources.
null_resource.named_test_resource: Creation complete after 2s [id=7567824024805792228]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=39a72006b4350c0df1ae4b9837453591e451bb0c]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqmitawet5osx74ooz565dodrw7qyobwjztircmsbeve7q"
resource_name = "OCI Configuration Detector Recipe"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqmitawet5osx74ooz565dodrw7qyobwjztircmsbeve7q",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Configuration Detector Recipe"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqmitawet5osx74ooz565dodrw7qyobwjztircmsbeve7q",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Configuration Detector Recipe"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "OCI Configuration Detector Recipe"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_detector_recipe

TEARDOWN: tests/oci_cloud_guard_detector_recipe

SUMMARY:

1/1 passed.


SETUP: tests/oci_cloud_guard_managed_list []

PRETEST: tests/oci_cloud_guard_managed_list

TEST: tests/oci_cloud_guard_managed_list
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_managed_list/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_id   = (known after apply)
  + resource_name = (known after apply)
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard managed-list list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_managed_list/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/.oci/config are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/.oci/config
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/Downloads/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/Downloads/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: This operation supports pagination and not all resources were returned.  Re-run using the --all option to auto paginate and list all resources.
null_resource.named_test_resource: Creation complete after 1s [id=9089015951576810515]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=310b001e6df3f7d8a7dc2a8b0c35d53240c41c40]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguardmanagedlist.oc1.ap-hyderabad-1.amaaaaaa6igdexcqendgqz72bxu6trygkd2b3deoysdnx6shcmh3kkq3yhqq"
resource_name = "Oracle Cloudguard CIDR Managed List"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguardmanagedlist.oc1.ap-hyderabad-1.amaaaaaa6igdexcqendgqz72bxu6trygkd2b3deoysdnx6shcmh3kkq3yhqq",
    "lifecycle_state": "ACTIVE",
    "name": "Oracle Cloudguard CIDR Managed List"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguardmanagedlist.oc1.ap-hyderabad-1.amaaaaaa6igdexcqendgqz72bxu6trygkd2b3deoysdnx6shcmh3kkq3yhqq",
    "lifecycle_state": "ACTIVE",
    "name": "Oracle Cloudguard CIDR Managed List"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "Oracle Cloudguard CIDR Managed List"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_managed_list

TEARDOWN: tests/oci_cloud_guard_managed_list

SUMMARY:

1/1 passed.

SETUP: tests/oci_cloud_guard_responder_recipe []

PRETEST: tests/oci_cloud_guard_responder_recipe

TEST: tests/oci_cloud_guard_responder_recipe
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_responder_recipe/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_id   = (known after apply)
  + resource_name = (known after apply)
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard responder-recipe list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_responder_recipe/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/.oci/config are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/.oci/config
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/Downloads/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/Downloads/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: This operation supports pagination and not all resources were returned.  Re-run using the --all option to auto paginate and list all resources.
null_resource.named_test_resource: Creation complete after 1s [id=7972050598107648039]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=c4847a7acab17443d0ae9e9102361305c02992de]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq"
resource_name = "OCI Responder Recipe"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Responder Recipe"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq",
    "lifecycle_state": "ACTIVE",
    "name": "OCI Responder Recipe"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "OCI Responder Recipe"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_responder_recipe

TEARDOWN: tests/oci_cloud_guard_responder_recipe

SUMMARY:

1/1 passed.

SETUP: tests/oci_cloud_guard_target []

PRETEST: tests/oci_cloud_guard_target

TEST: tests/oci_cloud_guard_target
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_target/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_id   = (known after apply)
  + resource_name = (known after apply)
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci cloud-guard target list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/oci_cloud_guard_target/terraform/test/output.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/.oci/config are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/.oci/config
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/sourav/Downloads/-04-08-07-40.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/sourav/Downloads/-04-08-07-40.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource (local-exec): WARNING: This operation supports pagination and not all resources were returned.  Re-run using the --all option to auto paginate and list all resources.
null_resource.named_test_resource: Creation complete after 1s [id=102760079134136349]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=76b838d58ff5338b58167b1487f8d487a1128870]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_id = "ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq"
resource_name = "raj-target-test"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq"

Running SQL query: test-get-query.sql

[
  {
    "id": "ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq",
    "lifecycle_state": "ACTIVE",
    "name": "raj-target-test"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "id": "ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq",
    "lifecycle_state": "ACTIVE",
    "name": "raj-target-test"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "raj-target-test"
  }
]
✔ PASSED

POSTTEST: tests/oci_cloud_guard_target

TEARDOWN: tests/oci_cloud_guard_target

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_cloud_guard_configuration
+------------------+---------+-----------------------+---------------------------------------------------------------------------------+
| reporting_region | status  | self_manage_resources | tenant_id                                                                       |
+------------------+---------+-----------------------+---------------------------------------------------------------------------------+
| ap-hyderabad-1   | ENABLED | false                 | ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq |
+------------------+---------+-----------------------+---------------------------------------------------------------------------------+
> select name, id, lifecycle_state from oci_cloud_guard_detector_recipe
+-----------------------------------+----------------------------------------------------------------------------------------------------------------+-----------------+
| name                              | id                                                                                                             | lifecycle_state |
+-----------------------------------+----------------------------------------------------------------------------------------------------------------+-----------------+
| raj-cloned-dtr-receipe            | ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexaadgvy5vs2g4qv4pwuzbtdhlnrfuuwnvkmlf7swxif5ppq | ACTIVE          |
| OCI Activity Detector Recipe      | ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqm6whfhgdutacouo5bwjejragnteqyp7q6wq2rk2vkf7a | ACTIVE          |
| OCI Configuration Detector Recipe | ocid1.cloudguarddetectorrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqmitawet5osx74ooz565dodrw7qyobwjztircmsbeve7q | ACTIVE          |
+-----------------------------------+----------------------------------------------------------------------------------------------------------------+-----------------+
> select name, id, lifecycle_state from oci_cloud_guard_managed_list
+-------------------------------------+-------------------------------------------------------------------------------------------------------------+-----------------+
| name                                | id                                                                                                          | lifecycle_state |
+-------------------------------------+-------------------------------------------------------------------------------------------------------------+-----------------+
| Oracle Cloudguard CIDR Managed List | ocid1.cloudguardmanagedlist.oc1.ap-hyderabad-1.amaaaaaa6igdexcqendgqz72bxu6trygkd2b3deoysdnx6shcmh3kkq3yhqq | ACTIVE          |
+-------------------------------------+-------------------------------------------------------------------------------------------------------------+-----------------+
> select name, id, lifecycle_state from oci_cloud_guard_responder_recipe
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
| name                 | id                                                                                                              | lifecycle_state |
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
| OCI Responder Recipe | ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq | ACTIVE          |
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
> select name, id, lifecycle_state from oci_cloud_guard_target
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+
| name            | id                                                                                                     | lifecycle_state |
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+
| raj-target-test | ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq | ACTIVE          |
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+


> select name, id, lifecycle_state from oci_cloud_guard_target where id = 'ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq'
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+
| name            | id                                                                                                     | lifecycle_state |
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+
| raj-target-test | ocid1.cloudguardtarget.oc1.ap-hyderabad-1.amaaaaaa6igdexaa6p57ctpclaabdd3nwiesfowlktnehgds2oyb2fuqbqgq | ACTIVE          |
+-----------------+--------------------------------------------------------------------------------------------------------+-----------------+
> select name, id, lifecycle_state from oci_cloud_guard_responder_recipe where id = 'ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq'
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
| name                 | id                                                                                                              | lifecycle_state |
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
| OCI Responder Recipe | ocid1.cloudguardresponderrecipe.oc1.ap-hyderabad-1.amaaaaaa6igdexcqtjtvx42p7ax73uqrgebirh6kmcucko74em6uvtzlmfqq | ACTIVE          |
+----------------------+-----------------------------------------------------------------------------------------------------------------+-----------------+
```
</details>
