### PR TITLE
Add table oci_objectstorage_object. Closes #338

### DIFF
--- a/docs/tables/oci_objectstorage_object.md
+++ b/docs/tables/oci_objectstorage_object.md
@@ -1,6 +1,6 @@
 # Table: oci_objectstorage_object
 
-In the Oracle Cloud Infrastructure Object Storage service, an object is a file or unstructured data you upload to a bucket within a compartment  within an Object Storage namespace. The object can be any type of data, for example, multimedia files, data backups, static web content, or logs.
+In the Oracle Cloud Infrastructure Object Storage service, an object is a file or unstructured data you upload to a bucket within a compartment within an Object Storage namespace. The object can be any type of data, for example, multimedia files, data backups, static web content, or logs.
 
 ## Examples
 

--- a/docs/tables/oci_objectstorage_object.md
+++ b/docs/tables/oci_objectstorage_object.md
@@ -1,0 +1,37 @@
+# Table: oci_objectstorage_object
+
+In the Oracle Cloud Infrastructure Object Storage service, an object is a file or unstructured data you upload to a bucket within a compartment  within an Object Storage namespace. The object can be any type of data, for example, multimedia files, data backups, static web content, or logs.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  bucket_name,
+  namespace,
+  region,
+  size,
+  md5,
+  time_created,
+  time_modified
+from
+  oci_objectstorage_object;
+```
+
+
+### List archived objects
+
+```sql
+select
+  name,
+  bucket_name,
+  namespace,
+  region,
+  archival_state
+from
+  oci_objectstorage_object
+where
+  archival_state = 'Archived';
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -132,6 +132,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_nosql_table_metric_write_throttle_count_daily":                 tableOciNoSQLTableMetricWriteThrottleCountDaily(ctx),
 			"oci_nosql_table_metric_write_throttle_count_hourly":                tableOciNoSQLTableMetricWriteThrottleCountHourly(ctx),
 			"oci_objectstorage_bucket":                                          tableObjectStorageBucket(ctx),
+			"oci_objectstorage_object":                                          tableObjectStorageObject(ctx),
 			"oci_ons_notification_topic":                                        tableOnsNotificationTopic(ctx),
 			"oci_ons_subscription":                                              tableOnsSubscription(ctx),
 			"oci_region":                                                        tableIdentityRegion(ctx),

--- a/oci/table_oci_objectstorage_object.go
+++ b/oci/table_oci_objectstorage_object.go
@@ -137,7 +137,7 @@ func tableObjectStorageObject(_ context.Context) *plugin.Table {
 				Description: "Time that the object is returned to the archived state. This field is only present for restored objects.",
 				Hydrate:     getObjectStorageObject,
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("TimeCreated.Time"),
+				Transform:   transform.FromField("TimeOfArchival.Time"),
 			},
 			{
 				Name:        "version_id",

--- a/oci/table_oci_objectstorage_object.go
+++ b/oci/table_oci_objectstorage_object.go
@@ -22,7 +22,7 @@ func tableObjectStorageObject(_ context.Context) *plugin.Table {
 			Hydrate:       listObjectStorageObjects,
 			ParentHydrate: listObjectStorageBuckets,
 		},
-		GetMatrixItem: BuildCompartementRegionList,
+		GetMatrixItem: BuildRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -90,7 +90,7 @@ func tableObjectStorageObject(_ context.Context) *plugin.Table {
 				Description: "The date and time after which the object is no longer cached by a browser, proxy, or other caching entity.",
 				Hydrate:     getObjectStorageObject,
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("TimeCreated.Time"),
+				Transform:   transform.FromField("Expires.Time"),
 			},
 			{
 				Name:        "is_not_modified",

--- a/oci/table_oci_objectstorage_object.go
+++ b/oci/table_oci_objectstorage_object.go
@@ -22,7 +22,7 @@ func tableObjectStorageObject(_ context.Context) *plugin.Table {
 			Hydrate:       listObjectStorageObjects,
 			ParentHydrate: listObjectStorageBuckets,
 		},
-		GetMatrixItem: BuildRegionList,
+		GetMatrixItem: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "name",
@@ -94,7 +94,7 @@ func tableObjectStorageObject(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "is_not_modified",
-				Description: "Flag to indicate whether or not the object was modified.  If this is true,the getter for the object itself will return null.",
+				Description: "Flag to indicate whether or not the object was modified. If this is true, the getter for the object itself will return null.",
 				Hydrate:     getObjectStorageObject,
 				Type:        proto.ColumnType_BOOL,
 				Default:     false,

--- a/oci/table_oci_objectstorage_object.go
+++ b/oci/table_oci_objectstorage_object.go
@@ -1,0 +1,283 @@
+package oci
+
+import (
+	"context"
+
+	"github.com/oracle/oci-go-sdk/v44/common"
+	"github.com/oracle/oci-go-sdk/v44/objectstorage"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableObjectStorageObject(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_objectstorage_object",
+		Description: "OCI Object Storage Object",
+		// Object can have same name in two different buckets, regions or compartments, leading to duplicate result in get call
+		List: &plugin.ListConfig{
+			Hydrate:       listObjectStorageObjects,
+			ParentHydrate: listObjectStorageBuckets,
+		},
+		GetMatrixItem: BuildCompartementRegionList,
+		Columns: []*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the object.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "bucket_name",
+				Description: "The name of the bucket.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "namespace",
+				Description: "The Object Storage namespace used for the request.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "archival_state",
+				Description: "Archival state of an object. This field is set only for objects in Archive tier.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "cache_control",
+				Description: "The Cache-Control header.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "content_disposition",
+				Description: "The Content-Disposition header.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "content_encoding",
+				Description: "The Content-Encoding header.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "content_language",
+				Description: "The Content-Language header.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "content_range",
+				Description: "Content-Range header for range requests.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "content_type",
+				Description: "The Content-Type header.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "etag",
+				Description: "The current entity tag (ETag) for the object.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "expires",
+				Description: "The date and time after which the object is no longer cached by a browser, proxy, or other caching entity.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+			{
+				Name:        "is_not_modified",
+				Description: "Flag to indicate whether or not the object was modified.  If this is true,the getter for the object itself will return null.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_BOOL,
+				Default:     false,
+			},
+			{
+				Name:        "md5",
+				Description: "Base64-encoded MD5 hash of the object data.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "opc_multipart_md5",
+				Description: "Base-64 representation of the multipart object hash. Only applicable to objects uploaded using multipart upload.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "size",
+				Description: "Size of the object in bytes.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "storage_tier",
+				Description: "The storage tier that the object is stored in.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "time_created",
+				Description: "The date and time the object was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+			{
+				Name:        "time_modified",
+				Description: "The date and time the object was modified.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeModified.Time"),
+			},
+			{
+				Name:        "time_of_archival",
+				Description: "Time that the object is returned to the archived state. This field is only present for restored objects.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+			{
+				Name:        "version_id",
+				Description: "The version ID of the object requested.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VersionId"),
+			},
+			{
+				Name:        "opc_meta",
+				Description: "The user-defined metadata for the object.",
+				Hydrate:     getObjectStorageObject,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Standard Steampipe columns
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+
+			// Standard OCI columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenant,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+type objectInfo struct {
+	BucketName string
+	Namespace string
+	Region string
+	objectstorage.ObjectSummary
+}
+
+//// LIST FUNCTION
+
+func listObjectStorageObjects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	logger.Trace("listObjectStorageObjects", "OCI_REGION", region)
+
+	bucketName := *h.Item.(bucketInfo).Name
+
+	objectNameSpace, err := getNamespace(ctx, d, region)
+	if err != nil {
+		logger.Error("listObjectStorageObjects", "error_getNamespace", region)
+		return nil, err
+	}
+
+	// Create Session
+	session, err := objectStorageService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	request := objectstorage.ListObjectsRequest{
+		BucketName:    &bucketName,
+		NamespaceName: &objectNameSpace.Value,
+		Fields:        types.String("name,size,etag,timeCreated,md5,timeModified,storageTier,archivalState"),
+		Limit:         types.Int(1000),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	response, err := session.ObjectStorageClient.ListObjects(ctx, request)
+	if err != nil {
+		logger.Error("listObjectStorageObjects", "error_ListObjects", err)
+		return nil, err
+	}
+
+	for _, objectSummary := range response.Objects {
+		d.StreamListItem(ctx, objectInfo{bucketName, objectNameSpace.Value, region, objectSummary})
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTION
+
+func getObjectStorageObject(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getObjectStorageObject")
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	logger.Debug("getObjectStorageObject", "OCI_REGION", region)
+
+	var bucketName, namespace, objectName string
+	if h.Item != nil {
+		info := h.Item.(objectInfo)
+		bucketName = info.BucketName
+		objectName = *info.Name
+		namespace = info.Namespace
+	}
+
+	// Create Session
+	session, err := objectStorageService(ctx, d, region)
+	if err != nil {
+		logger.Error("getObjectStorageObject", "error_objectStorageService", err)
+		return nil, err
+	}
+
+	request := objectstorage.GetObjectRequest{
+		NamespaceName: &namespace,
+		BucketName:    &bucketName,
+		ObjectName:    &objectName,
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+
+	response, err := session.ObjectStorageClient.GetObject(ctx, request)
+	if err != nil {
+		logger.Error("getObjectStorageObject", "error_GetObject", err)
+		if ociErr, ok := err.(common.ServiceError); ok {
+			if ociErr.GetCode() == "NotRestored" {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	return response, nil
+}


### PR DESCRIPTION
# Integration test logs
**Tests not feasible**

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  bucket_name,
  namespace,
  region,
  size,
  md5,
  time_created,
  time_modified
from
  oci_objectstorage_object;
+-------------------------+----------------------+--------------+--------------+--------+--------------------------+---------------------------+---------------------------+
| name                    | bucket_name          | namespace    | region       | size   | md5                      | time_created              | time_modified             |
+-------------------------+----------------------+--------------+--------------+--------+--------------------------+---------------------------+---------------------------+
| test-obj-1object.txt    | test-buket           | bmqeqvslavsz | ap-mumbai-1  | 517    | Q9MZB7Gof0gwLmQxy7eC8g== | 2022-01-06T14:21:38+05:30 | 2022-01-06T14:21:38+05:30 |
| test-obj-rootoutput.txt | bucket-20210809-1006 | bmqeqvslavsz | ap-mumbai-1  | 301627 | sJEN1kBLnBYNd2yrsa9+Og== | 2022-01-17T12:42:31+05:30 | 2022-01-17T12:42:31+05:30 |
| test-obj-1object.txt    | test-buket           | bmqeqvslavsz | us-ashburn-1 | 517    | Q9MZB7Gof0gwLmQxy7eC8g== | 2022-01-06T14:24:09+05:30 | 2022-01-06T14:24:09+05:30 |
| test-obj-2object-2.txt  | test-bucket-archive  | bmqeqvslavsz | us-ashburn-1 | 33     | ylXBDBbwMN/612uBh+xKZg== | 2022-01-12T12:45:14+05:30 | 2022-01-12T12:45:14+05:30 |
| test-obj-1object.txt    | test-bucket-archive  | bmqeqvslavsz | us-ashburn-1 | 33     | /0XMODUWUwfvQUwjyixvZw== | 2022-01-12T12:44:56+05:30 | 2022-01-12T12:44:56+05:30 |
| test-obj-2object-2.txt  | test-buket           | bmqeqvslavsz | us-ashburn-1 | 33     | ylXBDBbwMN/612uBh+xKZg== | 2022-01-12T12:58:53+05:30 | 2022-01-12T12:58:53+05:30 |
+-------------------------+----------------------+--------------+--------------+--------+--------------------------+---------------------------+---------------------------+
> select
  name,
  bucket_name,
  namespace,
  region,
  archival_state
from
  oci_objectstorage_object
where
  archival_state = 'Archived';
+------------------------+---------------------+--------------+--------------+----------------+
| name                   | bucket_name         | namespace    | region       | archival_state |
+------------------------+---------------------+--------------+--------------+----------------+
| test-obj-1object.txt   | test-bucket-archive | bmqeqvslavsz | us-ashburn-1 | Archived       |
| test-obj-2object-2.txt | test-bucket-archive | bmqeqvslavsz | us-ashburn-1 | Archived       |
+------------------------+---------------------+--------------+--------------+----------------+
> select * from oci_objectstorage_object limit 1
+----------------------+-------------+--------------+----------------+---------------+---------------------+------------------+------------------+---------------+--------------+---------------------------
| name                 | bucket_name | namespace    | archival_state | cache_control | content_disposition | content_encoding | content_language | content_range | content_type | etag                      
+----------------------+-------------+--------------+----------------+---------------+---------------------+------------------+------------------+---------------+--------------+---------------------------
| test-obj-1object.txt | test-buket  | bmqeqvslavsz |                | <null>        | attachment          | <null>           | <null>           | <null>        | text/plain   | d558915e-813e-461e-b506-e0
+----------------------+-------------+--------------+----------------+---------------+---------------------+------------------+------------------+---------------+--------------+---------------------------
```
</details>
