### PR TITLE
Update column type for column time_created to TIMESTAMP in oci_objectstorage_bucket table. Fixes #347

### DIFF
--- a/oci/table_oci_objectstorage_bucket.go
+++ b/oci/table_oci_objectstorage_bucket.go
@@ -126,7 +126,8 @@ func tableObjectStorageBucket(_ context.Context) *plugin.Table {
 			{
 				Name:        "time_created",
 				Description: "The date and time the bucket was created.",
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
 			},
 			{
 				Name:        "versioning",


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, time_created from oci_objectstorage_bucket
+----------------------+---------------------------+
| name                 | time_created              |
+----------------------+---------------------------+
| bucket-20210809-1006 | 2021-08-09T19:35:03+05:30 |
| test-buket           | 2022-01-06T14:16:59+05:30 |
| test-bucket-archive  | 2022-01-12T12:37:34+05:30 |
| test-buket           | 2022-01-06T14:23:01+05:30 |
+----------------------+---------------------------+
```
</details>
