### PR TITLE
Add table oci_mysql_db_system_metric_cpu_utilization_hourly closes #351

### DIFF
--- a/docs/tables/oci_mysql_db_system_metric_cpu_utilization_hourly.md
+++ b/docs/tables/oci_mysql_db_system_metric_cpu_utilization_hourly.md
@@ -1,0 +1,40 @@
+# Table: oci_mysql_db_system_metric_cpu_utilization_hourly
+
+OCI Monitoring metrics explorer provide data about the performance of your systems. The `oci_mysql_db_system_metric_cpu_utilization_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  timestamp,
+  minimum,
+  maximum,
+  average,
+  sample_count
+from
+  oci_mysql_db_system_metric_cpu_utilization_hourly
+order by
+  id,
+  timestamp;
+```
+
+### CPU Over 80% average
+
+```sql
+select
+  id,
+  timestamp,
+  round(minimum::numeric,2) as min_cpu,
+  round(maximum::numeric,2) as max_cpu,
+  round(average::numeric,2) as avg_cpu,
+  sample_count
+from
+  oci_mysql_db_system_metric_cpu_utilization_hourly
+where average > 80
+order by
+  id,
+  timestamp;
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -120,6 +120,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_mysql_db_system_metric_connections_daily":                      tableOciMySQLDBSystemMetricConnectionsDaily(ctx),
 			"oci_mysql_db_system_metric_cpu_utilization":                        tableOciMySQLDBSystemMetricCpuUtilization(ctx),
 			"oci_mysql_db_system_metric_cpu_utilization_daily":                  tableOciMySQLDBSystemMetricCpuUtilizationDaily(ctx),
+			"oci_mysql_db_system_metric_cpu_utilization_hourly":                 tableOciMySQLDBSystemMetricCpuUtilizationHourly(ctx),
 			"oci_mysql_db_system_metric_memory_utilization":                     tableOciMySQLDBSystemMetricMemoryUtilization(ctx),
 			"oci_mysql_db_system_metric_memory_utilization_daily":               tableOciMySQLDBSystemMetricMemoryUtilizationDaily(ctx),
 			"oci_nosql_table":                                                   tableNoSQLTable(ctx),

--- a/oci/table_oci_mysql_db_system_metric_cpu_utilization_hourly.go
+++ b/oci/table_oci_mysql_db_system_metric_cpu_utilization_hourly.go
@@ -1,0 +1,45 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/v44/mysql"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableOciMySQLDBSystemMetricCpuUtilizationHourly(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_mysql_db_system_metric_cpu_utilization_hourly",
+		Description: "OCI MySQL DB System Monitoring Metrics - CPU Utilization (Hourly)",
+		List: &plugin.ListConfig{
+			ParentHydrate: listMySQLDBSystems,
+			Hydrate:       listMySQLDBSystemMetricCpuUtilizationHourly,
+		},
+		GetMatrixItem: BuildCompartementRegionList,
+		Columns: MonitoringMetricColumns(
+			[]*plugin.Column{
+				{
+					Name:        "id",
+					Description: "The OCID of the DB System.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("DimensionValue"),
+				},
+			}),
+	}
+}
+
+func listMySQLDBSystemMetricCpuUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	dbSystem := h.Item.(mysql.DbSystemSummary)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*dbSystem.Id))
+
+	if dbSystem.LifecycleState == "DELETING" || dbSystem.LifecycleState == "DELETED" {
+		return nil, nil
+	}
+
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_mysql_database", "CPUUtilization", "resourceId", *dbSystem.Id, *dbSystem.CompartmentId, region)
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  timestamp,
  minimum,
  maximum,
  average,
  sample_count
from
  oci_mysql_db_system_metric_cpu_utilization_hourly
order by
  id,
  timestamp;
+------------------------------------------------------------------------------------------+---------------------------+---------+---------+--------------------+--------------+
| id                                                                                       | timestamp                 | minimum | maximum | average            | sample_count |
+------------------------------------------------------------------------------------------+---------------------------+---------+---------+--------------------+--------------+
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-11T22:30:00+05:30 | 0.99    | 99.95   | 16.665131578947364 | 304          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-11T23:30:00+05:30 | 0.85    | 85.66   | 11.736091644204851 | 371          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T00:30:00+05:30 | 0.95    | 89.92   | 13.062493224932252 | 369          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T01:30:00+05:30 | 0.9     | 100     | 11.35664864864865  | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T02:30:00+05:30 | 0.95    | 95.3    | 12.302567567567568 | 370          |

```

```
> select
  id,
  timestamp,
  round(minimum::numeric,2) as min_cpu,
  round(maximum::numeric,2) as max_cpu,
  round(average::numeric,2) as avg_cpu,
  sample_count
from
  oci_mysql_db_system_metric_cpu_utilization_hourly
where average > 12
order by
  id,
  timestamp;
+------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| id                                                                                       | timestamp                 | min_cpu | max_cpu | avg_cpu | sample_count |
+------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-11T22:30:00+05:30 | 0.99    | 99.95   | 16.67   | 304          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T00:30:00+05:30 | 0.95    | 89.92   | 13.06   | 369          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T02:30:00+05:30 | 0.95    | 95.30   | 12.30   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T03:30:00+05:30 | 0.95    | 100.00  | 13.07   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T04:30:00+05:30 | 0.90    | 58.59   | 12.03   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T06:30:00+05:30 | 0.85    | 85.60   | 12.61   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T07:30:00+05:30 | 0.85    | 95.81   | 12.25   | 371          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T08:30:00+05:30 | 0.85    | 97.82   | 12.54   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T09:30:00+05:30 | 0.85    | 88.89   | 12.61   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T10:30:00+05:30 | 0.90    | 96.54   | 13.67   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T11:30:00+05:30 | 6.35    | 99.80   | 18.38   | 371          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T12:30:00+05:30 | 0.80    | 99.90   | 13.72   | 370          |
| ocid1.mysqldbsystem.oc1.iad.aaaaaaaadx5774xlclnzrf4czrki7p27hhzyawbp5jp7wfqfsb7ikofz2uxa | 2022-02-12T13:30:00+05:30 | 0.85    | 94.04   | 12.53   | 371          |

```
</details>
