### PR TITLE
Add table oci_database_autonomous_database_metric_cpu_utilization_hourly closes #350

### DIFF
--- a/docs/tables/oci_database_autonomous_database_metric_cpu_utilization_hourly.md
+++ b/docs/tables/oci_database_autonomous_database_metric_cpu_utilization_hourly.md
@@ -1,0 +1,40 @@
+# Table: oci_database_autonomous_database_metric_cpu_utilization_hourly
+
+OCI Monitoring metrics explorer provide data about the performance of your systems. The `oci_database_autonomous_database_metric_cpu_utilization_hourly` table provides metric statistics at 1 hour intervals for the most recent 60 days.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  timestamp,
+  minimum,
+  maximum,
+  average,
+  sample_count
+from
+  oci_database_autonomous_database_metric_cpu_utilization_hourly
+order by
+  id,
+  timestamp;
+```
+
+### CPU Over 80% average
+
+```sql
+select
+  id,
+  timestamp,
+  round(minimum::numeric,2) as min_cpu,
+  round(maximum::numeric,2) as max_cpu,
+  round(average::numeric,2) as avg_cpu,
+  sample_count
+from
+  oci_database_autonomous_database_metric_cpu_utilization_hourly
+where average > 80
+order by
+  id,
+  timestamp;
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -77,7 +77,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_database_autonomous_database":                                  tableOciDatabaseAutonomousDatabase(ctx),
 			"oci_database_autonomous_database_metric_cpu_utilization":           tableOciDatabaseAutonomousDatabaseMetricCpuUtilization(ctx),
 			"oci_database_autonomous_database_metric_cpu_utilization_daily":     tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationDaily(ctx),
-			"oci_database_autonomous_database_metric_cpu_utilization_hourly":     tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationHourly(ctx),
+			"oci_database_autonomous_database_metric_cpu_utilization_hourly":    tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationHourly(ctx),
 			"oci_database_autonomous_database_metric_storage_utilization":       tableOciDatabaseAutonomousDatabaseMetricStorageUtilization(ctx),
 			"oci_database_autonomous_database_metric_storage_utilization_daily": tableOciDatabaseAutonomousDatabaseMetricStorageUtilizationDaily(ctx),
 			"oci_database_db":                                                   tableOciDatabase(ctx),

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -77,6 +77,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_database_autonomous_database":                                  tableOciDatabaseAutonomousDatabase(ctx),
 			"oci_database_autonomous_database_metric_cpu_utilization":           tableOciDatabaseAutonomousDatabaseMetricCpuUtilization(ctx),
 			"oci_database_autonomous_database_metric_cpu_utilization_daily":     tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationDaily(ctx),
+			"oci_database_autonomous_database_metric_cpu_utilization_hourly":     tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationHourly(ctx),
 			"oci_database_autonomous_database_metric_storage_utilization":       tableOciDatabaseAutonomousDatabaseMetricStorageUtilization(ctx),
 			"oci_database_autonomous_database_metric_storage_utilization_daily": tableOciDatabaseAutonomousDatabaseMetricStorageUtilizationDaily(ctx),
 			"oci_database_db":                                                   tableOciDatabase(ctx),

--- a/oci/table_oci_database_autonomous_database_cpu_utilization_hourly.go
+++ b/oci/table_oci_database_autonomous_database_cpu_utilization_hourly.go
@@ -1,0 +1,40 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/v44/database"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationHourly(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_database_autonomous_database_metric_cpu_utilization_hourly",
+		Description: "OCI Autonomous Database Monitoring Metrics - CPU Utilization (Hourly)",
+		List: &plugin.ListConfig{
+			ParentHydrate: listAutonomousDatabases,
+			Hydrate:       listAutonomousDatabaseMetricCpuUtilizationHourly,
+		},
+		GetMatrixItem: BuildCompartementRegionList,
+		Columns: MonitoringMetricColumns(
+			[]*plugin.Column{
+				{
+					Name:        "id",
+					Description: "The OCID of the Autonomous Database.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("DimensionValue"),
+				},
+			}),
+	}
+}
+
+func listAutonomousDatabaseMetricCpuUtilizationHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	database := h.Item.(database.AutonomousDatabaseSummary)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*database.Id))
+	return listMonitoringMetricStatistics(ctx, d, "HOURLY", "oci_autonomous_database", "CpuUtilization", "resourceId", *database.Id, *database.CompartmentId, region)
+}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_database_autonomous_database_metric_cpu_utilization_hourly
+-----------------------------------------------------------------------------------------------+----------------+-------------------------+--------------------+--------------------+-------------------+--
| id                                                                                            | metric_name    | namespace               | average            | maximum            | minimum           | s
+-----------------------------------------------------------------------------------------------+----------------+-------------------------+--------------------+--------------------+-------------------+--
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | CpuUtilization | oci_autonomous_database | 0.7693703731003496 | 16.308860858840685 | 0                 | 6
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | CpuUtilization | oci_autonomous_database | 14.09853909763048  | 19.918589043363117 | 8.594009522435433 | 1
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | CpuUtilization | oci_autonomous_database | 0.3975942083727084 | 6.583248316498317  | 0                 | 6
+-----------------------------------------------------------------------------------------------+----------------+-------------------------+--------------------+--------------------+-------------------+--
> select
  id,
  timestamp,
  minimum,
  maximum,
  average,
  sample_count
from
  oci_database_autonomous_database_metric_cpu_utilization_hourly
order by
  id,
  timestamp;
+-----------------------------------------------------------------------------------------------+---------------------------+-------------------+--------------------+--------------------+--------------+
| id                                                                                            | timestamp                 | minimum           | maximum            | average            | sample_count |
+-----------------------------------------------------------------------------------------------+---------------------------+-------------------+--------------------+--------------------+--------------+
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | 2022-02-15T13:00:00+05:30 | 8.594009522435433 | 19.918589043363117 | 14.09853909763048  | 15           |
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | 2022-02-15T14:00:00+05:30 | 0                 | 16.308860858840685 | 0.7693703731003496 | 60           |
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | 2022-02-15T15:00:00+05:30 | 0                 | 6.583248316498317  | 0.3975942083727084 | 60           |
+-----------------------------------------------------------------------------------------------+---------------------------+-------------------+--------------------+--------------------+--------------+
> select
  id,
  timestamp,
  round(minimum::numeric,2) as min_cpu,
  round(maximum::numeric,2) as max_cpu,
  round(average::numeric,2) as avg_cpu,
  sample_count
from
  oci_database_autonomous_database_metric_cpu_utilization_hourly
where average > 10
order by
  id,
  timestamp;
+-----------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| id                                                                                            | timestamp                 | min_cpu | max_cpu | avg_cpu | sample_count |
+-----------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| ocid1.autonomousdatabase.oc1.iad.anuwcljr6igdexaakf7wn6rbogmtwh4ky2iwrjk4v4y3ovpz4rcuuu2j325a | 2022-02-15T13:00:00+05:30 | 8.59    | 19.92   | 14.10   | 15           |
+-----------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
```
</details>
