### PR TITLE
Fix table oci_dns_rrset for error InvalidParameter in list call closes #356

### DIFF
--- a/oci/table_oci_dns_rrset.go
+++ b/oci/table_oci_dns_rrset.go
@@ -133,7 +133,7 @@ func listDnsRecordSets(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	request := dns.GetZoneRecordsRequest{
 		ZoneNameOrId:  zone.Id,
 		CompartmentId: types.String(compartment),
-		Limit:         types.Int64(1000),
+		Limit:         types.Int64(100),
 		RequestMetadata: common.RequestMetadata{
 			RetryPolicy: getDefaultRetryPolicy(),
 		},


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_dns_rrset' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_dns_rrset []

PRETEST: tests/oci_dns_rrset

TEST: tests/oci_dns_rrset
Running terraform
oci_dns_zone.named_test_resource: Creating...
oci_dns_zone.named_test_resource: Still creating... [10s elapsed]
oci_dns_zone.named_test_resource: Still creating... [20s elapsed]
oci_dns_zone.named_test_resource: Creation complete after 28s [id=ocid1.dns-zone.oc1..f86ed5f4e4614b399bfeccd42e9975f7]
oci_dns_rrset.named_test_resource: Creating...
oci_dns_rrset.named_test_resource: Still creating... [10s elapsed]
oci_dns_rrset.named_test_resource: Creation complete after 17s [id=zoneNameOrId/steampipetest.com/domain/test/rtype/NS]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

domain = steampipetest.com
rtype = NS
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-list-query.sql

[
  {
    "domain": "steampipetest.com",
    "is_protected": true,
    "rtype": "NS",
    "ttl": "86400"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest.com"
  }
]
✔ PASSED

POSTTEST: tests/oci_dns_rrset

TEARDOWN: tests/oci_dns_rrset

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_dns_rrset
+------------+----------------------------------+----------------------------------------------------------------------------+--------------+---------------+-------+-------+------------+----------------
| domain     | record_hash                      | rdata                                                                      | is_protected | rrset_version | rtype | ttl   | title      | compartment_id 
+------------+----------------------------------+----------------------------------------------------------------------------+--------------+---------------+-------+-------+------------+----------------
| turbot.com | 4d95407268e1842e35d2c0601412c084 | ns1.p68.dns.oraclecloud.net.                                               | true         | 1             | NS    | 86400 | turbot.com | ocid1.tenancy.o
| turbot.com | 5bda38277c7d71916f749f677dd16577 | ns3.p68.dns.oraclecloud.net.                                               | true         | 1             | NS    | 86400 | turbot.com | ocid1.tenancy.o
| turbot.com | ef47c6be691f11c82eb7069a72edaf8b | ns4.p68.dns.oraclecloud.net.                                               | true         | 1             | NS    | 86400 | turbot.com | ocid1.tenancy.o
| turbot.com | c57d145d8149c8b04a7d14cacc8f4c56 | ns2.p68.dns.oraclecloud.net.                                               | true         | 1             | NS    | 86400 | turbot.com | ocid1.tenancy.o
| turbot.com | c402acee89d4f578d3d849f4da2ecb17 | ns1.p68.dns.oraclecloud.net. hostmaster.turbot.com. 1 3600 600 604800 1800 | true         | 1             | SOA   | 300   | turbot.com | ocid1.tenancy.o
+------------+----------------------------------+----------------------------------------------------------------------------+--------------+---------------+-------+-------+------------+---------------
```
</details>
