### PR TITLE
Fix column name lifecycle_state in oci_core_vnic_attachment table closes #367

### DIFF
--- a/oci/table_oci_core_vnic_attachment.go
+++ b/oci/table_oci_core_vnic_attachment.go
@@ -67,7 +67,7 @@ func tableCoreVnicAttachment(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "lifecycle_state`",
+				Name:        "lifecycle_state",
 				Description: "The current state of the VNIC attachment. Possible values include: 'ATTACHING', 'ATTACHED', 'DETACHING', 'DETACHED'.",
 				Type:        proto.ColumnType_STRING,
 			},


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>
  
```
> .inspect oci_core_vnic_attachment
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| column                 | type                     | description                                                                                                                                        |
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| _ctx                   | jsonb                    | Steampipe context in JSON form, e.g. connection_name.                                                                                              |
| availability_domain    | text                     | The availability domain of the instance.                                                                                                           |
| compartment_id         | text                     | The OCID of the compartment in Tenant in which the resource is located.                                                                            |
| defined_tags           | jsonb                    | Defined tags for resource. Defined tags are set up in your tenancy by an administrator. Only users granted permission to work with the defined tag |
|                        |                          | s can apply them to resources.                                                                                                                     |
| display_name           | text                     | A user-friendly name for the VNIC attachment.                                                                                                      |
| freeform_tags          | jsonb                    | Free-form tags for resource. This tags can be applied by any user with permissions on the resource.                                                |
| hostname_label         | text                     | The hostname for the VNIC's primary private IP.                                                                                                    |
| id                     | text                     | The OCID of the VNIC attachment.                                                                                                                   |
| instance_id            | text                     | The OCID of the instance.                                                                                                                          |
| is_primary             | boolean                  | Whether the VNIC is the primary VNIC (the VNIC that is automatically created and attached during instance launch).                                 |
| lifecycle_state`       | text                     | The current state of the VNIC attachment. Possible values include: 'ATTACHING', 'ATTACHED', 'DETACHING', 'DETACHED'.                               |
| mac_address            | text                     | The MAC address of the VNIC.                                                                                                                       |
| nic_index              | bigint                   | The physical network interface card (NIC) the VNIC uses.                                                                                           |
| nsg_ids                | jsonb                    | A list of the OCIDs of the network security groups that the VNIC belongs to.                                                                       |
| private_ip             | text                     | The private IP address of the primary `privateIp` object on the VNIC.                                                                              |
| public_ip              | text                     | The public IP address of the VNIC, if one is assigned.                                                                                             |
| region                 | text                     | The OCI region in which the resource is located.                                                                                                   |
| skip_source_dest_check | boolean                  | Whether the source/destination check is disabled on the VNIC. Defaults to `false`, which means the check is performed.                             |
| subnet_id              | text                     | The OCID of the subnet to create the VNIC in.                                                                                                      |
| tags                   | jsonb                    | A map of tags for the resource.                                                                                                                    |
| tenant_id              | text                     | The OCID of the Tenant in which the resource is located.                                                                                           |
| time_created           | timestamp with time zone | The date and time the VNIC attachment was created.                                                                                                 |
| title                  | text                     | Title of the resource.                                                                                                                             |
| vlan_id                | text                     | The OCID of the VLAN to create the VNIC in.                                                                                                        |
| vlan_tag               | bigint                   | The OCID of the VNIC.                                                                                                                              |
| vnic_id                | text                     | The OCID of the VNIC.                                                                                                                              |
| vnic_name              | text                     | A user-friendly name for the VNIC.                                                                                                                 |
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+


> .inspect oci_core_vnic_attachment
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| column                 | type                     | description                                                                                                                                        |
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
| _ctx                   | jsonb                    | Steampipe context in JSON form, e.g. connection_name.                                                                                              |
| availability_domain    | text                     | The availability domain of the instance.                                                                                                           |
| compartment_id         | text                     | The OCID of the compartment in Tenant in which the resource is located.                                                                            |
| defined_tags           | jsonb                    | Defined tags for resource. Defined tags are set up in your tenancy by an administrator. Only users granted permission to work with the defined tag |
|                        |                          | s can apply them to resources.                                                                                                                     |
| display_name           | text                     | A user-friendly name for the VNIC attachment.                                                                                                      |
| freeform_tags          | jsonb                    | Free-form tags for resource. This tags can be applied by any user with permissions on the resource.                                                |
| hostname_label         | text                     | The hostname for the VNIC's primary private IP.                                                                                                    |
| id                     | text                     | The OCID of the VNIC attachment.                                                                                                                   |
| instance_id            | text                     | The OCID of the instance.                                                                                                                          |
| is_primary             | boolean                  | Whether the VNIC is the primary VNIC (the VNIC that is automatically created and attached during instance launch).                                 |
| lifecycle_state        | text                     | The current state of the VNIC attachment. Possible values include: 'ATTACHING', 'ATTACHED', 'DETACHING', 'DETACHED'.                               |
| mac_address            | text                     | The MAC address of the VNIC.                                                                                                                       |
| nic_index              | bigint                   | The physical network interface card (NIC) the VNIC uses.                                                                                           |
| nsg_ids                | jsonb                    | A list of the OCIDs of the network security groups that the VNIC belongs to.                                                                       |
| private_ip             | text                     | The private IP address of the primary `privateIp` object on the VNIC.                                                                              |
| public_ip              | text                     | The public IP address of the VNIC, if one is assigned.                                                                                             |
| region                 | text                     | The OCI region in which the resource is located.                                                                                                   |
| skip_source_dest_check | boolean                  | Whether the source/destination check is disabled on the VNIC. Defaults to `false`, which means the check is performed.                             |
| subnet_id              | text                     | The OCID of the subnet to create the VNIC in.                                                                                                      |
| tags                   | jsonb                    | A map of tags for the resource.                                                                                                                    |
| tenant_id              | text                     | The OCID of the Tenant in which the resource is located.                                                                                           |
| time_created           | timestamp with time zone | The date and time the VNIC attachment was created.                                                                                                 |
| title                  | text                     | Title of the resource.                                                                                                                             |
| vlan_id                | text                     | The OCID of the VLAN to create the VNIC in.                                                                                                        |
| vlan_tag               | bigint                   | The OCID of the VNIC.                                                                                                                              |
| vnic_id                | text                     | The OCID of the VNIC.                                                                                                                              |
| vnic_name              | text                     | A user-friendly name for the VNIC.                                                                                                                 |
+------------------------+--------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>
