### PR TITLE
Added table oci_mysql_db_system_metric_connections_hourly. Closes #379

### DIFF
--- a/docs/tables/oci_mysql_db_system_metric_connections_hourly.md
+++ b/docs/tables/oci_mysql_db_system_metric_connections_hourly.md
@@ -1,0 +1,58 @@
+# Table: oci_mysql_db_system_metric_connections_hourly
+
+OCI Monitoring metrics explorer provide data about the performance of your systems. The `oci_mysql_db_system_metric_connections_hourly` table provides metric statistics at 60 minutes intervals for the most recent 60 days.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  timestamp,
+  minimum,
+  maximum,
+  average,
+  sample_count
+from
+  oci_mysql_db_system_metric_connections_hourly
+order by
+  id,
+  timestamp;
+```
+
+### Active connection statistics
+
+```sql
+select
+  id,
+  timestamp,
+  round(minimum::numeric,2) as min_conn,
+  round(maximum::numeric,2) as max_conn,
+  round(average::numeric,2) as avg_conn,
+  sample_count
+from
+  oci_mysql_db_system_metric_connections_hourly
+where metric_name = 'ActiveConnections'
+order by
+  id,
+  timestamp;
+```
+
+### Current connection statistics
+
+```sql
+select
+  id,
+  timestamp,
+  round(minimum::numeric,2) as min_conn,
+  round(maximum::numeric,2) as max_conn,
+  round(average::numeric,2) as avg_conn,
+  sample_count
+from
+  oci_mysql_db_system_metric_connections_hourly
+where metric_name = 'CurrentConnections'
+order by
+  id,
+  timestamp;
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -121,6 +121,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_mysql_db_system":                                          tableMySQLDBSystem(ctx),
 			"oci_mysql_db_system_metric_connections":                       tableOciMySQLDBSystemMetricConnections(ctx),
 			"oci_mysql_db_system_metric_connections_daily":                 tableOciMySQLDBSystemMetricConnectionsDaily(ctx),
+			"oci_mysql_db_system_metric_connections_hourly":                tableOciMySQLDBSystemMetricConnectionsHourly(ctx),
 			"oci_mysql_db_system_metric_cpu_utilization":                   tableOciMySQLDBSystemMetricCpuUtilization(ctx),
 			"oci_mysql_db_system_metric_cpu_utilization_daily":             tableOciMySQLDBSystemMetricCpuUtilizationDaily(ctx),
 			"oci_mysql_db_system_metric_cpu_utilization_hourly":            tableOciMySQLDBSystemMetricCpuUtilizationHourly(ctx),

--- a/oci/table_oci_mysql_db_system_metric_connections_hourly.go
+++ b/oci/table_oci_mysql_db_system_metric_connections_hourly.go
@@ -1,0 +1,50 @@
+package oci
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oracle/oci-go-sdk/v44/mysql"
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableOciMySQLDBSystemMetricConnectionsHourly(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_mysql_db_system_metric_connections_hourly",
+		Description: "OCI MySQL DB System Monitoring Metrics - Current/Active Connections (Hourly)",
+		List: &plugin.ListConfig{
+			ParentHydrate: listMySQLDBSystems,
+			Hydrate:       listMySQLDBSystemMetricConnectionsHourly,
+		},
+		GetMatrixItem: BuildCompartementRegionList,
+		Columns: MonitoringMetricColumns(
+			[]*plugin.Column{
+				{
+					Name:        "id",
+					Description: "The OCID of the DB System.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("DimensionValue"),
+				},
+			}),
+	}
+}
+
+func listMySQLDBSystemMetricConnectionsHourly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	dbSystem := h.Item.(mysql.DbSystemSummary)
+	region := fmt.Sprintf("%v", ociRegionNameFromId(*dbSystem.Id))
+
+	if dbSystem.LifecycleState == "DELETING" || dbSystem.LifecycleState == "DELETED" {
+		return nil, nil
+	}
+
+	_, err := listMonitoringMetricStatistics(ctx, d, "Hourly", "oci_mysql_database", "ActiveConnections", "resourceId", *dbSystem.Id, *dbSystem.CompartmentId, region)
+	if err != nil {
+		return nil, err
+	}
+
+	return listMonitoringMetricStatistics(ctx, d, "Hourly", "oci_mysql_database", "CurrentConnections", "resourceId", *dbSystem.Id, *dbSystem.CompartmentId, region)
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  timestamp,
  round(minimum::numeric,2) as min_conn,
  round(maximum::numeric,2) as max_conn,
  round(average::numeric,2) as avg_conn,
  sample_count
from
  oci_mysql_db_system_metric_connections_hourly
where metric_name = 'CurrentConnections'
order by
  id,
  timestamp limit 3;
+--------------------------------------------------------------------------------------------------+---------------------------+----------+----------+----------+--------------+
| id                                                                                               | timestamp                 | min_conn | max_conn | avg_conn | sample_count |
+--------------------------------------------------------------------------------------------------+---------------------------+----------+----------+----------+--------------+
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T19:00:00+05:30 | 1.00     | 1.00     | 1.00     | 105          |
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T20:00:00+05:30 | 1.00     | 1.00     | 1.00     | 367          |
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T21:00:00+05:30 | 1.00     | 1.00     | 1.00     | 367          |
+--------------------------------------------------------------------------------------------------+---------------------------+----------+----------+----------+--------------+

> select
  id,
  timestamp,
  minimum,
  maximum,
  average,
  sample_count
from
  oci_mysql_db_system_metric_connections_hourly
order by
  id,
  timestamp limit 3;
+--------------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| id                                                                                               | timestamp                 | minimum | maximum | average | sample_count |
+--------------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T19:00:00+05:30 | 2       | 2       | 2       | 105          |
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T19:00:00+05:30 | 1       | 1       | 1       | 105          |
| ocid1.mysqldbsystem.oc1.ap-mumbai-1.aaaaaaaa4wztu7ox5xb4y4bnlrcrnutdl7t3hkhazd54rzrmpwk7lyeod5mq | 2022-03-21T20:00:00+05:30 | 2       | 2       | 2       | 367          |
+--------------------------------------------------------------------------------------------------+---------------------------+---------+---------+---------+--------------+


```
</details>
