### PR TITLE
Add table oci_database_pluggable_database. Closes #290

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.9.0 [2022-03-10]
+
+_Enhancements_
+
+- Added `volume_backup_policy_id` and `volume_backup_policy_assignment_id` columns to `oci_core_boot_volume` table ([#371](https://github.com/turbot/steampipe-plugin-oci/pull/371))
+- Added `volume_backup_policy_id` and `volume_backup_policy_assignment_id` columns to `oci_core_volume` table ([#371](https://github.com/turbot/steampipe-plugin-oci/pull/371))
+
 ## v0.8.1 [2022-02-24]
 
 _Bug fixes_
@@ -28,7 +35,7 @@ _Enhancements_
 _Bug fixes_
 
 - Fixed the lower limit in the `oci_dns_rrset` table ([#357](https://github.com/turbot/steampipe-plugin-oci/pull/357))
-- Updated the column type  of `time_created` column to `TIMESTAMP` in `oci_objectstorage_bucket` table ([#348](https://github.com/turbot/steampipe-plugin-oci/pull/348))
+- Updated the column type of `time_created` column to `TIMESTAMP` in `oci_objectstorage_bucket` table ([#348](https://github.com/turbot/steampipe-plugin-oci/pull/348))
 
 ## v0.7.0 [2022-01-19]
 
@@ -70,7 +77,7 @@ _Bug fixes_
 
 _Enhancements_
 
-- Updated: Add additional optional key quals, filter support, and context cancellation handling and improve hydrate with cache functionality across all the  tables ([#306](https://github.com/turbot/steampipe-plugin-oci/pull/306)) ([#317](https://github.com/turbot/steampipe-plugin-oci/pull/317))
+- Updated: Add additional optional key quals, filter support, and context cancellation handling and improve hydrate with cache functionality across all the tables ([#306](https://github.com/turbot/steampipe-plugin-oci/pull/306)) ([#317](https://github.com/turbot/steampipe-plugin-oci/pull/317))
 - Updated: Add `title` column in `oci_ons_subscription` table ([#313](https://github.com/turbot/steampipe-plugin-oci/pull/313))
 
 ## v0.3.1 [2021-09-13]

--- a/docs/tables/oci_database_pluggable_database.md
+++ b/docs/tables/oci_database_pluggable_database.md
@@ -16,7 +16,7 @@ from
   oci_database_pluggable_database;
 ```
 
-### List unavailable pluggable databases
+### List failed pluggable databases
 
 ```sql
 select
@@ -27,7 +27,7 @@ select
 from
   oci_database_pluggable_database
 where
-  lifecycle_state <> 'AVAILABLE';
+  lifecycle_state = 'FAILED';
 ```
 
 ### List pluggable databases older than 90 days

--- a/docs/tables/oci_database_pluggable_database.md
+++ b/docs/tables/oci_database_pluggable_database.md
@@ -29,3 +29,19 @@ from
 where
   lifecycle_state <> 'AVAILABLE';
 ```
+
+### List pluggable databases older than 90 days
+
+```sql
+select
+  pdb_name,
+  id,
+  lifecycle_state,
+  time_created
+from
+  oci_database_pluggable_database
+where
+  time_created <= (current_date - interval '90' day)
+order by
+  time_created;
+```

--- a/docs/tables/oci_database_pluggable_database.md
+++ b/docs/tables/oci_database_pluggable_database.md
@@ -1,0 +1,31 @@
+# Table: oci_database_pluggable_database
+
+A pluggable database (PDB) is portable collection of schemas, schema objects, and non-schema objects that appears to an Oracle client as a non-container database.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  pdb_name,
+  id,
+  lifecycle_state,
+  time_created
+from
+  oci_database_pluggable_database;
+```
+
+### List pluggable databases that are not available
+
+```sql
+select
+  pdb_name,
+  id,
+  lifecycle_state,
+  time_created
+from
+  oci_database_pluggable_database
+where
+  lifecycle_state <> 'AVAILABLE';
+```

--- a/docs/tables/oci_database_pluggable_database.md
+++ b/docs/tables/oci_database_pluggable_database.md
@@ -45,3 +45,17 @@ where
 order by
   time_created;
 ```
+
+### List unrestricted pluggable databases
+
+```sql
+select
+  pdb_name,
+  id,
+  lifecycle_state,
+  is_restricted
+from
+  oci_database_pluggable_database
+where
+  not is_restricted;
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -85,6 +85,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_database_db":                                              tableOciDatabase(ctx),
 			"oci_database_db_home":                                         tableOciDatabaseDBHome(ctx),
 			"oci_database_db_system":                                       tableOciDatabaseDBSystem(ctx),
+			"oci_database_pluggable_database":                              tableOciPluggableDatabase(ctx),
 			"oci_database_software_image":                                  tableOciDatabaseSoftwareImage(ctx),
 			"oci_dns_rrset":                                                tableDnsRecordSet(ctx),
 			"oci_dns_tsig_key":                                             tableDnsTsigKey(ctx),

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -1,0 +1,297 @@
+package oci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v44/common"
+	"github.com/oracle/oci-go-sdk/v44/database"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
+)
+
+func tableOciPluggableDatabase(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_database_pluggable_database",
+		Description: "OCI Pluggable Database",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getPluggableDatabase,
+		},
+		List: &plugin.ListConfig{
+			ShouldIgnoreError: isNotFoundError([]string{"404"}),
+			ParentHydrate:     listDatabases,
+			Hydrate:           listPluggableDatabases,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "compartment_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "pdb_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "lifecycle_state",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItem: BuildCompartementRegionList,
+		Columns: []*plugin.Column{
+			{
+				Name:        "pdb_name",
+				Description: "The name for the pluggable database. The name is unique in the context of a Database. The name must begin with an alphabetic character and can contain a maximum of thirty alphanumeric characters. Special characters are not permitted. The pluggable database name should not be same as the container database name.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "id",
+				Description: "The OCID of the pluggable database.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromCamel(),
+			},
+			{
+				Name:        "lifecycle_state",
+				Description: "The current state of the pluggable database.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "time_created",
+				Description: "The date and time the pluggable database was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+			{
+				Name:        "container_database_id",
+				Description: "The OCID of the CDB.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "is_restricted",
+				Description: "The restricted mode of pluggableDatabase. If a pluggableDatabase is opened in restricted mode, the user needs both Create a session and restricted session privileges to connect to it.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "lifecycle_details",
+				Description: "Detailed message for the lifecycle state.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "open_mode",
+				Description: "The mode that pluggableDatabase is in. Open mode can only be changed to READ_ONLY or MIGRATE directly from the backend.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "connection_strings",
+				Description: "The connection strings used to connect to the oracle pluggable database.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// tags
+			{
+				Name:        "defined_tags",
+				Description: ColumnDescriptionDefinedTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "freeform_tags",
+				Description: ColumnDescriptionFreefromTags,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(pluggableDatabaseTags),
+			},
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("PdbName"),
+			},
+
+			// OCI standard columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Id").Transform(ociRegionName),
+			},
+			{
+				Name:        "compartment_id",
+				Description: ColumnDescriptionCompartment,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CompartmentId"),
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenant,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listPluggableDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	logger.Debug("listPluggableDatabases", "Compartment", compartment, "OCI_REGION", region)
+
+	equalQuals := d.KeyColumnQuals
+
+	// Return nil, if given compartment_id doesn't match
+	if equalQuals["compartment_id"] != nil && compartment != equalQuals["compartment_id"].GetStringValue() {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := databaseService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	databaseId := h.Item.(database.DatabaseSummary).Id
+
+	request := database.ListPluggableDatabasesRequest{
+		CompartmentId: types.String(compartment),
+		DatabaseId:    databaseId,
+		Limit:         types.Int(1000),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+
+	// Check for additional filters
+	if equalQuals["pdb_name"] != nil {
+		dbName := equalQuals["pdb_name"].GetStringValue()
+		request.PdbName = types.String(dbName)
+	}
+
+	if equalQuals["lifecycle_state"] != nil {
+		lifecycleState := equalQuals["lifecycle_state"].GetStringValue()
+		request.LifecycleState = database.PluggableDatabaseSummaryLifecycleStateEnum(lifecycleState)
+	}
+
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := session.DatabaseClient.ListPluggableDatabases(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, database := range response.Items {
+			d.StreamListItem(ctx, database)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.OpcNextPage != nil {
+			request.Page = response.OpcNextPage
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTION
+
+func getPluggableDatabase(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	logger.Debug("getPluggableDatabase", "Compartment", compartment, "OCI_REGION", region)
+
+	// Restrict the api call to only root compartment/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+		return nil, nil
+	}
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+
+	// handle empty id in get call
+	if id == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := databaseService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	request := database.GetPluggableDatabaseRequest{
+		PluggableDatabaseId: types.String(id),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(),
+		},
+	}
+
+	response, err := session.DatabaseClient.GetPluggableDatabase(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.PluggableDatabase, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func pluggableDatabaseTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	var freeformTags map[string]string
+	var definedTags map[string]map[string]interface{}
+
+	switch d.HydrateItem.(type) {
+	case database.PluggableDatabaseSummary:
+		database := d.HydrateItem.(database.PluggableDatabaseSummary)
+		freeformTags = database.FreeformTags
+		definedTags = database.DefinedTags
+	case database.PluggableDatabase:
+		database := d.HydrateItem.(database.PluggableDatabase)
+		freeformTags = database.FreeformTags
+		definedTags = database.DefinedTags
+	}
+
+	var tags map[string]interface{}
+
+	if freeformTags != nil {
+		tags = map[string]interface{}{}
+		for k, v := range freeformTags {
+			tags[k] = v
+		}
+	}
+
+	if definedTags != nil {
+		if tags == nil {
+			tags = map[string]interface{}{}
+		}
+		for _, v := range definedTags {
+			for key, value := range v {
+				tags[key] = value
+			}
+
+		}
+	}
+
+	return tags, nil
+}

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -22,7 +22,7 @@ func tableOciPluggableDatabase(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			ShouldIgnoreError: isNotFoundError([]string{"404"}),
-			Hydrate:           listPluggableDatabases,
+			Hydrate:           listDatabasePluggableDatabases,
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "compartment_id",
@@ -141,7 +141,7 @@ func tableOciPluggableDatabase(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listPluggableDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func listDatabasePluggableDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
@@ -209,7 +209,6 @@ func listPluggableDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.
 			pagesLeft = false
 		}
 	}
-
 	return nil, err
 }
 
@@ -250,7 +249,6 @@ func getPluggableDatabase(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	if err != nil {
 		return nil, err
 	}
-
 	return response.PluggableDatabase, nil
 }
 
@@ -288,7 +286,6 @@ func pluggableDatabaseTags(_ context.Context, d *transform.TransformData) (inter
 			for key, value := range v {
 				tags[key] = value
 			}
-
 		}
 	}
 

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -176,7 +176,7 @@ func listDatabasePluggableDatabases(ctx context.Context, d *plugin.QueryData, h 
 
 	if equalQuals["lifecycle_state"] != nil {
 		lifecycleState := equalQuals["lifecycle_state"].GetStringValue()
-		if isValidState(lifecycleState) {
+		if isValidPluggableDatabaseSummaryLifecycleState(lifecycleState) {
 			request.LifecycleState = database.PluggableDatabaseSummaryLifecycleStateEnum(lifecycleState)
 		} else {
 			return nil, nil
@@ -294,7 +294,7 @@ func pluggableDatabaseTags(_ context.Context, d *transform.TransformData) (inter
 	return tags, nil
 }
 
-func isValidState(state string) bool {
+func isValidPluggableDatabaseSummaryLifecycleState(state string) bool {
 	stateType := database.PluggableDatabaseSummaryLifecycleStateEnum(state)
 	switch stateType {
 	case database.PluggableDatabaseSummaryLifecycleStateProvisioning, database.PluggableDatabaseSummaryLifecycleStateAvailable, database.PluggableDatabaseSummaryLifecycleStateFailed, database.PluggableDatabaseSummaryLifecycleStateTerminated, database.PluggableDatabaseSummaryLifecycleStateTerminating, database.PluggableDatabaseSummaryLifecycleStateUpdating:

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -178,6 +178,8 @@ func listDatabasePluggableDatabases(ctx context.Context, d *plugin.QueryData, h 
 		lifecycleState := equalQuals["lifecycle_state"].GetStringValue()
 		if isValidState(lifecycleState) {
 			request.LifecycleState = database.PluggableDatabaseSummaryLifecycleStateEnum(lifecycleState)
+		} else {
+			return nil, nil
 		}
 	}
 

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -263,13 +263,13 @@ func pluggableDatabaseTags(_ context.Context, d *transform.TransformData) (inter
 
 	switch d.HydrateItem.(type) {
 	case database.PluggableDatabaseSummary:
-		database := d.HydrateItem.(database.PluggableDatabaseSummary)
-		freeformTags = database.FreeformTags
-		definedTags = database.DefinedTags
+		pDatabaseSummary := d.HydrateItem.(database.PluggableDatabaseSummary)
+		freeformTags = pDatabaseSummary.FreeformTags
+		definedTags = pDatabaseSummary.DefinedTags
 	case database.PluggableDatabase:
-		database := d.HydrateItem.(database.PluggableDatabase)
-		freeformTags = database.FreeformTags
-		definedTags = database.DefinedTags
+		pDatabase := d.HydrateItem.(database.PluggableDatabase)
+		freeformTags = pDatabase.FreeformTags
+		definedTags = pDatabase.DefinedTags
 	}
 
 	var tags map[string]interface{}

--- a/oci/table_oci_database_pluggable_database.go
+++ b/oci/table_oci_database_pluggable_database.go
@@ -22,7 +22,6 @@ func tableOciPluggableDatabase(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			ShouldIgnoreError: isNotFoundError([]string{"404"}),
-			ParentHydrate:     listDatabases,
 			Hydrate:           listPluggableDatabases,
 			KeyColumns: []*plugin.KeyColumn{
 				{
@@ -160,11 +159,8 @@ func listPluggableDatabases(ctx context.Context, d *plugin.QueryData, h *plugin.
 		return nil, err
 	}
 
-	databaseId := h.Item.(database.DatabaseSummary).Id
-
 	request := database.ListPluggableDatabasesRequest{
 		CompartmentId: types.String(compartment),
-		DatabaseId:    databaseId,
 		Limit:         types.Int(1000),
 		RequestMetadata: common.RequestMetadata{
 			RetryPolicy: getDefaultRetryPolicy(),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
TF resource creation for the parent resource DB system has issues, also CLI is not feasible.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  pdb_name,
  id,
  lifecycle_state,
  time_created
from
  oci_database_pluggable_database
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+
| pdb_name    | id                                                                                                   | lifecycle_state | time_created              |
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+
| DB0324_pdb1 | ocid1.pluggabledatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaagk5z4f32sheetvpgzrutdku2vmtl72kpcj3xqzes6wxq | TERMINATED      | 2022-03-24T12:43:32+05:30 |
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+

> select
  pdb_name,
  id,
  lifecycle_state,
  time_created
from
  oci_database_pluggable_database
where
  lifecycle_state <> 'AVAILABLE'
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+
| pdb_name    | id                                                                                                   | lifecycle_state | time_created              |
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+
| DB0324_pdb1 | ocid1.pluggabledatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaagk5z4f32sheetvpgzrutdku2vmtl72kpcj3xqzes6wxq | TERMINATED      | 2022-03-24T12:43:32+05:30 |
+-------------+------------------------------------------------------------------------------------------------------+-----------------+---------------------------+
```
</details>
