### PR TITLE
Add column ipv6_cidr_blocks in oci_core_vcn table. Closes #389

### DIFF
--- a/oci/table_oci_core_vcn.go
+++ b/oci/table_oci_core_vcn.go
@@ -95,7 +95,7 @@ func tableCoreVcn(_ context.Context) *plugin.Table {
 			{
 				Name:        "ipv6_cidr_block",
 				Description: "For an IPv6-enabled VCN, this is the IPv6 CIDR block for the VCN's private IP address space.",
-				Type:        proto.ColumnType_JSON,
+				Type:        proto.ColumnType_CIDR,
 				Transform:   transform.FromField("Ipv6CidrBlock"),
 			},
 			{

--- a/oci/table_oci_core_vcn.go
+++ b/oci/table_oci_core_vcn.go
@@ -95,7 +95,7 @@ func tableCoreVcn(_ context.Context) *plugin.Table {
 			{
 				Name:        "ipv6_cidr_block",
 				Description: "For an IPv6-enabled VCN, this is the IPv6 CIDR block for the VCN's private IP address space.",
-				Type:        proto.ColumnType_CIDR,
+				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Ipv6CidrBlock"),
 			},
 			{
@@ -113,6 +113,12 @@ func tableCoreVcn(_ context.Context) *plugin.Table {
 				Name:        "cidr_blocks",
 				Description: "The list of IPv4 CIDR blocks the VCN will use.",
 				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "ipv6_cidr_blocks",
+				Description: "For an IPv6-enabled VCN, this is the list of IPv6 CIDR blocks for the VCN's IP address space. The CIDRs are provided by Oracle and the sizes are always /56.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Ipv6CidrBlocks"),
 			},
 
 			// tags


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select display_name,ipv6_cidr_blocks from oci_core_vcn
+-------------------+------------------------------+
| display_name      | ipv6_cidr_blocks             |
+-------------------+------------------------------+
| vcn-20220222-1132 | <null>                       |
| vcn-20220208-1530 | ["2603:c021:4000:e000::/56"] |
| vcn-20220209-1247 | <null>                       |
+-------------------+------------------------------+

```
</details>
