### PR TITLE
Fix list call for table oci_core_image_custom closes #378

### DIFF
--- a/oci/table_oci_core_image_custom.go
+++ b/oci/table_oci_core_image_custom.go
@@ -209,7 +209,11 @@ func listCoreCustomImages(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 		}
 
 		for _, image := range response.Items {
-			if image.BaseImageId != nil {
+			/* Custom immages can be created by two ways.
+			* 1. Importing the image from bucket (In this case we will have OperatingSystem value as 'Custom' and BaseImageId will be null)
+			* 2. Exporting an image from an instance (In this case we will have OperatingSystem value as as per the instance OS image and BaseImageId will not be null)
+			*/
+			if image.BaseImageId != nil || *image.OperatingSystem == "Custom" {
 				d.StreamListItem(ctx, image)
 			}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_core_image_custom' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_core_image_custom []

PRETEST: tests/oci_core_image_custom

TEST: tests/oci_core_image_custom
Running terraform
oci_core_vcn.named_test_resource: Creating...
oci_core_vcn.named_test_resource: Creation complete after 1s [id=ocid1.vcn.oc1.ap-mumbai-1.amaaaaaa6igdexaavnzau7rs6xaro37w2bbecbru2upqrwit3huv7xnzzj7a]
oci_core_subnet.named_test_resource: Creating...
oci_core_subnet.named_test_resource: Creation complete after 2s [id=ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa6oxhuynzgaajy33tf2ohqobpge5hb5jsh3akmds6bmzt7lucjltq]
null_resource.test_image: Creating...
null_resource.test_image: Provisioning with 'local-exec'...
null_resource.test_image (local-exec): Executing: ["/bin/sh" "-c" "oci compute image list --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --all --output json > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/oci_core_image_custom/terraform/test/image.json"]
null_resource.test_image (local-exec): WARNING: Permissions on /Users/parthas/Downloads/private.pem are too open.
null_resource.test_image (local-exec): To fix this please try executing the following command:
null_resource.test_image (local-exec): oci setup repair-file-permissions --file /Users/parthas/Downloads/private.pem
null_resource.test_image (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.test_image (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.test_image: Creation complete after 3s [id=4169499950046116969]
data.local_file.image: Refreshing state...
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci compute instance launch --availability-domain TvRS:AP-MUMBAI-1-AD-1 --compartment-id ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq --shape VM.Standard2.1 --subnet-id ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa6oxhuynzgaajy33tf2ohqobpge5hb5jsh3akmds6bmzt7lucjltq --image-id ocid1.image.oc1.ap-mumbai-1.aaaaaaaaqoc2njalbqzogp46glpzmnoqv7qdqllvegm2eimszcul476vkzzq --output json > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/oci_core_image_custom/terraform/test/instance.json"]
null_resource.named_test_resource (local-exec): WARNING: Permissions on /Users/parthas/Downloads/private.pem are too open.
null_resource.named_test_resource (local-exec): To fix this please try executing the following command:
null_resource.named_test_resource (local-exec): oci setup repair-file-permissions --file /Users/parthas/Downloads/private.pem
null_resource.named_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.named_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "sleep 150"]
null_resource.named_test_resource: Still creating... [10s elapsed]
null_resource.named_test_resource: Still creating... [20s elapsed]
null_resource.named_test_resource: Still creating... [30s elapsed]
null_resource.named_test_resource: Still creating... [40s elapsed]
null_resource.named_test_resource: Still creating... [50s elapsed]
null_resource.named_test_resource: Still creating... [1m0s elapsed]
null_resource.named_test_resource: Still creating... [1m10s elapsed]
null_resource.named_test_resource: Still creating... [1m20s elapsed]
null_resource.named_test_resource: Still creating... [1m30s elapsed]
null_resource.named_test_resource: Still creating... [1m40s elapsed]
null_resource.named_test_resource: Still creating... [1m50s elapsed]
null_resource.named_test_resource: Still creating... [2m0s elapsed]
null_resource.named_test_resource: Still creating... [2m10s elapsed]
null_resource.named_test_resource: Still creating... [2m20s elapsed]
null_resource.named_test_resource: Still creating... [2m30s elapsed]
null_resource.named_test_resource: Creation complete after 2m32s [id=2037084926112498186]
data.local_file.instance: Refreshing state...
oci_core_image.named_test_resource: Creating...
oci_core_image.named_test_resource: Still creating... [10s elapsed]
oci_core_image.named_test_resource: Still creating... [20s elapsed]
oci_core_image.named_test_resource: Still creating... [30s elapsed]
oci_core_image.named_test_resource: Still creating... [40s elapsed]
oci_core_image.named_test_resource: Still creating... [50s elapsed]
oci_core_image.named_test_resource: Still creating... [1m0s elapsed]
oci_core_image.named_test_resource: Still creating... [1m10s elapsed]
oci_core_image.named_test_resource: Still creating... [1m20s elapsed]
oci_core_image.named_test_resource: Still creating... [1m30s elapsed]
oci_core_image.named_test_resource: Still creating... [1m40s elapsed]
oci_core_image.named_test_resource: Still creating... [1m50s elapsed]
oci_core_image.named_test_resource: Still creating... [2m0s elapsed]
oci_core_image.named_test_resource: Still creating... [2m10s elapsed]
oci_core_image.named_test_resource: Still creating... [2m20s elapsed]
oci_core_image.named_test_resource: Still creating... [2m30s elapsed]
oci_core_image.named_test_resource: Still creating... [2m40s elapsed]
oci_core_image.named_test_resource: Still creating... [2m50s elapsed]
oci_core_image.named_test_resource: Still creating... [3m0s elapsed]
oci_core_image.named_test_resource: Still creating... [3m10s elapsed]
oci_core_image.named_test_resource: Still creating... [3m20s elapsed]
oci_core_image.named_test_resource: Still creating... [3m30s elapsed]
oci_core_image.named_test_resource: Still creating... [3m40s elapsed]
oci_core_image.named_test_resource: Still creating... [3m50s elapsed]
oci_core_image.named_test_resource: Still creating... [4m0s elapsed]
oci_core_image.named_test_resource: Still creating... [4m10s elapsed]
oci_core_image.named_test_resource: Still creating... [4m20s elapsed]
oci_core_image.named_test_resource: Still creating... [4m30s elapsed]
oci_core_image.named_test_resource: Still creating... [4m40s elapsed]
^[[D^[[Doci_core_image.named_test_resource: Still creating... [4m50s elapsed]
oci_core_image.named_test_resource: Still creating... [5m0s elapsed]
oci_core_image.named_test_resource: Still creating... [5m10s elapsed]
oci_core_image.named_test_resource: Still creating... [5m20s elapsed]
oci_core_image.named_test_resource: Still creating... [5m30s elapsed]
oci_core_image.named_test_resource: Still creating... [5m40s elapsed]
oci_core_image.named_test_resource: Still creating... [5m50s elapsed]
oci_core_image.named_test_resource: Still creating... [6m0s elapsed]
oci_core_image.named_test_resource: Still creating... [6m10s elapsed]
oci_core_image.named_test_resource: Still creating... [6m20s elapsed]
oci_core_image.named_test_resource: Still creating... [6m30s elapsed]
oci_core_image.named_test_resource: Still creating... [6m40s elapsed]
oci_core_image.named_test_resource: Still creating... [6m50s elapsed]
oci_core_image.named_test_resource: Still creating... [7m0s elapsed]
oci_core_image.named_test_resource: Still creating... [7m10s elapsed]
oci_core_image.named_test_resource: Still creating... [7m20s elapsed]
oci_core_image.named_test_resource: Still creating... [7m30s elapsed]
oci_core_image.named_test_resource: Still creating... [7m40s elapsed]
oci_core_image.named_test_resource: Still creating... [7m50s elapsed]
oci_core_image.named_test_resource: Still creating... [8m0s elapsed]
oci_core_image.named_test_resource: Still creating... [8m10s elapsed]
oci_core_image.named_test_resource: Still creating... [8m20s elapsed]
oci_core_image.named_test_resource: Still creating... [8m30s elapsed]
oci_core_image.named_test_resource: Still creating... [8m40s elapsed]
oci_core_image.named_test_resource: Still creating... [8m50s elapsed]
oci_core_image.named_test_resource: Still creating... [9m0s elapsed]
oci_core_image.named_test_resource: Still creating... [9m10s elapsed]
oci_core_image.named_test_resource: Still creating... [9m20s elapsed]
oci_core_image.named_test_resource: Still creating... [9m30s elapsed]
oci_core_image.named_test_resource: Still creating... [9m40s elapsed]
oci_core_image.named_test_resource: Still creating... [9m50s elapsed]
oci_core_image.named_test_resource: Still creating... [10m0s elapsed]
oci_core_image.named_test_resource: Still creating... [10m10s elapsed]
oci_core_image.named_test_resource: Still creating... [10m20s elapsed]
oci_core_image.named_test_resource: Still creating... [10m30s elapsed]
oci_core_image.named_test_resource: Still creating... [10m40s elapsed]
oci_core_image.named_test_resource: Still creating... [10m50s elapsed]
oci_core_image.named_test_resource: Still creating... [11m0s elapsed]
oci_core_image.named_test_resource: Still creating... [11m10s elapsed]
oci_core_image.named_test_resource: Still creating... [11m20s elapsed]
oci_core_image.named_test_resource: Still creating... [11m30s elapsed]
oci_core_image.named_test_resource: Still creating... [11m40s elapsed]
oci_core_image.named_test_resource: Still creating... [11m50s elapsed]
oci_core_image.named_test_resource: Still creating... [12m0s elapsed]
oci_core_image.named_test_resource: Still creating... [12m10s elapsed]
oci_core_image.named_test_resource: Still creating... [12m20s elapsed]
oci_core_image.named_test_resource: Still creating... [12m30s elapsed]
oci_core_image.named_test_resource: Still creating... [12m40s elapsed]
oci_core_image.named_test_resource: Still creating... [12m51s elapsed]
oci_core_image.named_test_resource: Still creating... [13m1s elapsed]
oci_core_image.named_test_resource: Still creating... [13m11s elapsed]
oci_core_image.named_test_resource: Still creating... [13m21s elapsed]
oci_core_image.named_test_resource: Still creating... [13m31s elapsed]
oci_core_image.named_test_resource: Still creating... [13m41s elapsed]
oci_core_image.named_test_resource: Still creating... [13m51s elapsed]
oci_core_image.named_test_resource: Still creating... [14m1s elapsed]
oci_core_image.named_test_resource: Still creating... [14m11s elapsed]
oci_core_image.named_test_resource: Still creating... [14m21s elapsed]
oci_core_image.named_test_resource: Still creating... [14m31s elapsed]
oci_core_image.named_test_resource: Still creating... [14m41s elapsed]
oci_core_image.named_test_resource: Still creating... [14m51s elapsed]
oci_core_image.named_test_resource: Still creating... [15m1s elapsed]
oci_core_image.named_test_resource: Still creating... [15m11s elapsed]
oci_core_image.named_test_resource: Still creating... [15m21s elapsed]
oci_core_image.named_test_resource: Still creating... [15m31s elapsed]
oci_core_image.named_test_resource: Still creating... [15m41s elapsed]
oci_core_image.named_test_resource: Still creating... [15m51s elapsed]
oci_core_image.named_test_resource: Still creating... [16m1s elapsed]
oci_core_image.named_test_resource: Still creating... [16m11s elapsed]
oci_core_image.named_test_resource: Still creating... [16m21s elapsed]
oci_core_image.named_test_resource: Still creating... [16m31s elapsed]
oci_core_image.named_test_resource: Still creating... [16m41s elapsed]
oci_core_image.named_test_resource: Still creating... [16m51s elapsed]
oci_core_image.named_test_resource: Still creating... [17m1s elapsed]
oci_core_image.named_test_resource: Still creating... [17m11s elapsed]
oci_core_image.named_test_resource: Still creating... [17m21s elapsed]
oci_core_image.named_test_resource: Still creating... [17m31s elapsed]
oci_core_image.named_test_resource: Still creating... [17m41s elapsed]
oci_core_image.named_test_resource: Still creating... [17m51s elapsed]
oci_core_image.named_test_resource: Still creating... [18m1s elapsed]
oci_core_image.named_test_resource: Still creating... [18m11s elapsed]
oci_core_image.named_test_resource: Creation complete after 18m11s [id=ocid1.image.oc1.ap-mumbai-1.aaaaaaaauzs4w5hrx6khtjkaf3uqst2eh6kcbz4cpuihuyrn6odgwrbpwzzq]
null_resource.destroy_test_resource: Creating...
null_resource.destroy_test_resource: Provisioning with 'local-exec'...
null_resource.destroy_test_resource (local-exec): Executing: ["/bin/sh" "-c" "oci compute instance terminate --instance-id ocid1.instance.oc1.ap-mumbai-1.anrg6ljr6igdexacgeng5ohzqz3yqqsvsgyyby3n7xwlpoviy3c62kelkmqa --force"]
null_resource.destroy_test_resource (local-exec): WARNING: Permissions on /Users/parthas/Downloads/private.pem are too open.
null_resource.destroy_test_resource (local-exec): To fix this please try executing the following command:
null_resource.destroy_test_resource (local-exec): oci setup repair-file-permissions --file /Users/parthas/Downloads/private.pem
null_resource.destroy_test_resource (local-exec): Alternatively to hide this warning, you may set the environment variable, OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING:
null_resource.destroy_test_resource (local-exec): export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True

null_resource.destroy_test_resource: Creation complete after 1s [id=8298570041071434959]

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

lifecycle_state = AVAILABLE
operating_system = Windows
operating_system_version = Server 2019 Standard
resource_id = ocid1.image.oc1.ap-mumbai-1.aaaaaaaauzs4w5hrx6khtjkaf3uqst2eh6kcbz4cpuihuyrn6odgwrbpwzzq
resource_name = steampipetest6733
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "display_name": "steampipetest6733",
    "id": "ocid1.image.oc1.ap-mumbai-1.aaaaaaaauzs4w5hrx6khtjkaf3uqst2eh6kcbz4cpuihuyrn6odgwrbpwzzq",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "display_name": "steampipetest6733",
    "id": "ocid1.image.oc1.ap-mumbai-1.aaaaaaaauzs4w5hrx6khtjkaf3uqst2eh6kcbz4cpuihuyrn6odgwrbpwzzq",
    "operating_system": "Windows",
    "operating_system_version": "Server 2019 Standard"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest6733"
  }
]
✔ PASSED

POSTTEST: tests/oci_core_image_custom

TEARDOWN: tests/oci_core_image_custom

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select display_name, operating_system, base_image_id from oci_core_image_custom where display_name = 'test-my-image';
+---------------+------------------+------------------------------------------------------------------------------------------+
| display_name  | operating_system | base_image_id                                                                            |
+---------------+------------------+------------------------------------------------------------------------------------------+
| test-my-image | Oracle Linux     | ocid1.image.oc1.ap-mumbai-1.aaaaaaaaekyt2v46comr7vcfnasistr5lnvwilq2xkfi4brcvgy4smdk6via |
+---------------+------------------+------------------------------------------------------------------------------------------+
```

```
> select display_name, operating_system, base_image_id from oci_core_image_custom;;
+------------------------------+------------------+------------------------------------------------------------------------------------------+
| display_name                 | operating_system | base_image_id                                                                            |
+------------------------------+------------------+------------------------------------------------------------------------------------------+
| imported-image-20220404-1505 | Custom           | <null>                                                                                   |
| test-my-image                | Oracle Linux     | ocid1.image.oc1.ap-mumbai-1.aaaaaaaaekyt2v46comr7vcfnasistr5lnvwilq2xkfi4brcvgy4smdk6via |
+------------------------------+------------------+------------------------------------------------------------------------------------------+
```

</details>
