### PR TITLE
Rename table oci_database_autonomous_dd_metric_storage_utilization to oci_database_autonomous_db_metric_storage_utilization closes #416

### DIFF
--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -80,7 +80,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_database_autonomous_db_metric_cpu_utilization":            tableOciDatabaseAutonomousDatabaseMetricCpuUtilization(ctx),
 			"oci_database_autonomous_db_metric_cpu_utilization_daily":      tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationDaily(ctx),
 			"oci_database_autonomous_db_metric_cpu_utilization_hourly":     tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationHourly(ctx),
-			"oci_database_autonomous_dd_metric_storage_utilization":        tableOciDatabaseAutonomousDatabaseMetricStorageUtilization(ctx),
+			"oci_database_autonomous_db_metric_storage_utilization":        tableOciDatabaseAutonomousDatabaseMetricStorageUtilization(ctx),
 			"oci_database_autonomous_db_metric_storage_utilization_daily":  tableOciDatabaseAutonomousDatabaseMetricStorageUtilizationDaily(ctx),
 			"oci_database_autonomous_db_metric_storage_utilization_hourly": tableOciDatabaseAutonomousDatabaseMetricStorageUtilizationHourly(ctx),
 			"oci_database_db":                                              tableOciDatabase(ctx),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_database_autonomous_db_metric_storage_utilization
+-------------------------------------------------------------------------------------------------------+--------------------+-------------------------+--------------------+--------------------+----------
| id                                                                                                    | metric_name        | namespace               | average            | maximum            | minimum  
+-------------------------------------------------------------------------------------------------------+--------------------+-------------------------+--------------------+--------------------+----------
| ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaai6jrpmw6feqlpotbccfoehzstdkd3yrdahsrifixoena | StorageUtilization | oci_autonomous_database | 0.6596371531486511 | 0.6596371531486511 | 0.6596371
| ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaai6jrpmw6feqlpotbccfoehzstdkd3yrdahsrifixoena | StorageUtilization | oci_autonomous_database | 0.6596371531486511 | 0.6596371531486511 | 0.6596371
| ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaai6jrpmw6feqlpotbccfoehzstdkd3yrdahsrifixoena | StorageUtilization | oci_autonomous_database | 0.6596371531486511 | 0.6596371531486511 | 0.6596371
| ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaai6jrpmw6feqlpotbccfoehzstdkd3yrdahsrifixoena | StorageUtilization | oci_autonomous_database | 0.6596371531486511 | 0.6596371531486511 | 0.6596371
+-------------------------------------------------------------------------------------------------------+--------------------+-------------------------+--------------------+--------------------+----------
```
</details>
