### PR TITLE
Fix the formatting of an example query in oci_identity_compartment table doc

### DIFF
--- a/docs/tables/oci_identity_compartment.md
+++ b/docs/tables/oci_identity_compartment.md
@@ -54,7 +54,7 @@ with recursive compartments as
     oci_identity_compartment.id,
     oci_identity_compartment.compartment_id,
     oci_identity_compartment.tenant_id,
-    oci_identity_compartment.name || '\' || compartments.path,
+    oci_identity_compartment.name || '/' || compartments.path,
     compartments.last_name,
     compartments.last_id
   from

--- a/docs/tables/oci_identity_compartment.md
+++ b/docs/tables/oci_identity_compartment.md
@@ -34,41 +34,43 @@ order by
 ### Full path of the compartments
 
 ```sql
-with recursive compartments as (
-select
-  name,
-  id,
-  compartment_id,
-  tenant_id,
-  name as path,
-  name as lastname,
-  id as lastid
-from 
-  oci_identity_compartment
-where
-  lifecycle_state = 'ACTIVE'
-
-union all
-
-select
-  oci_identity_compartment.name,
-  oci_identity_compartment.id,
-  oci_identity_compartment.compartment_id,
-  oci_identity_compartment.tenant_id,
-  oci_identity_compartment.name || '\' || compartments.path,
-  compartments.lastname,
-  compartments.lastid
-from 
-  oci_identity_compartment join 
-  compartments on oci_identity_compartment.id = compartments.compartment_id
+with recursive compartments as
+(
+  select
+    name,
+    id,
+    compartment_id,
+    tenant_id,
+    name as path,
+    name as last_name,
+    id as last_id
+  from
+    oci_identity_compartment
+  where
+    lifecycle_state = 'ACTIVE'
+  union all
+  select
+    oci_identity_compartment.name,
+    oci_identity_compartment.id,
+    oci_identity_compartment.compartment_id,
+    oci_identity_compartment.tenant_id,
+    oci_identity_compartment.name || '\' || compartments.path,
+    compartments.last_name,
+    compartments.last_id
+  from
+    oci_identity_compartment
+    join
+      compartments
+      on oci_identity_compartment.id = compartments.compartment_id
 )
 select
-  lastid as compartment_id,
-  lastname as name,
+  last_id as compartment_id,
+  last_name as name,
   path
-from 
+from
   compartments
-where 
+where
   compartment_id = tenant_id
-order by 
+order by
   path;
+```


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
