### PR TITLE
Add exports details in table oci_file_storage_file_system closes #448

### DIFF
--- a/oci/table_oci_file_storage_file_system.go
+++ b/oci/table_oci_file_storage_file_system.go
@@ -295,7 +295,7 @@ func getFileStorageFileSystemExports(ctx context.Context, d *plugin.QueryData, h
 		id = getFileSystemID(h.Item)
 	} else {
 		id = d.KeyColumnQuals["id"].GetStringValue()
-		// Restrict the api call to only root compartment and one zone/ per region
+		// Restrict the API call to only the root compartment and one zone/ per region
 		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
 			return nil, nil
 		}

--- a/oci/table_oci_file_storage_file_system.go
+++ b/oci/table_oci_file_storage_file_system.go
@@ -288,7 +288,6 @@ func getFileStorageFileSystemExports(ctx context.Context, d *plugin.QueryData, h
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
-	logger.Debug("getFileStorageFileSystem", "Compartment", compartment, "OCI_ZONE", zone)
 
 	var id string
 	if h.Item != nil {
@@ -309,6 +308,7 @@ func getFileStorageFileSystemExports(ctx context.Context, d *plugin.QueryData, h
 	// Create Session
 	session, err := fileStorageService(ctx, d, region)
 	if err != nil {
+		logger.Error("oci_file_storage_file_system.getFileStorageFileSystemExports", "connection_error", err)
 		return nil, err
 	}
 
@@ -322,6 +322,7 @@ func getFileStorageFileSystemExports(ctx context.Context, d *plugin.QueryData, h
 
 	response, err := session.FileStorageClient.ListExports(ctx, request)
 	if err != nil {
+		logger.Error("oci_file_storage_file_system.getFileStorageFileSystemExports", "api_error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_file_storage_file_system' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_file_storage_file_system []

PRETEST: tests/oci_file_storage_file_system

TEST: tests/oci_file_storage_file_system
Running terraform
oci_file_storage_file_system.named_test_resource: Creating...
oci_file_storage_file_system.named_test_resource: Creation complete after 3s [id=ocid1.filesystem.oc1.ap_mumbai_1.aaaaaaaaaaaa5wdcmjxw2llqojxwiotboaww25lnmjqwsljrfvqwiljr]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

availability_domain = TvRS:AP-MUMBAI-1-AD-1
freeform_tags = {
  "Name" = "steampipetest3613"
}
region = ap-mumbai-1
resource_id = ocid1.filesystem.oc1.ap_mumbai_1.aaaaaaaaaaaa5wdcmjxw2llqojxwiotboaww25lnmjqwsljrfvqwiljr
resource_name = steampipetest3613
tenancy_ocid = ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq

Running SQL query: test-get-query.sql

[
  {
    "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
    "display_name": "steampipetest3613",
    "freeform_tags": {
      "Name": "steampipetest3613"
    },
    "id": "ocid1.filesystem.oc1.ap_mumbai_1.aaaaaaaaaaaa5wdcmjxw2llqojxwiotboaww25lnmjqwsljrfvqwiljr",
    "is_clone_parent": false,
    "is_hydrated": true,
    "lifecycle_state": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
    "display_name": "steampipetest3613",
    "id": "ocid1.filesystem.oc1.ap_mumbai_1.aaaaaaaaaaaa5wdcmjxw2llqojxwiotboaww25lnmjqwsljrfvqwiljr",
    "lifecycle_state": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "region": "ap_mumbai_1",
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5soecxzjetci3yjjnjqmfkr4po3hoz4p4h2q37cyljaq",
    "title": "steampipetest3613"
  }
]
✔ PASSED

POSTTEST: tests/oci_file_storage_file_system

TEARDOWN: tests/oci_file_storage_file_system

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
+-----------------------------+------------------------------------------------------------------------------------------------------+
| display_name                | jsonb_pretty                                                                                         |
+-----------------------------+------------------------------------------------------------------------------------------------------+
| FileSystem-20230103-0702-23 | [                                                                                                    |
|                             |     {                                                                                                |
|                             |         "id": "ocid1.export.oc1.iad.aaaaaby27vgkedzwnfqwillqojxwiotjmfsc2ylefuzqaaaa",               |
|                             |         "path": "/FileSystem-20230103-0702-23",                                                      |
|                             |         "exportSetId": "ocid1.exportset.oc1.iad.aaaaaa4np2t5xfj6nfqwillqojxwiotjmfsc2ylefuzqaaaa",   |
|                             |         "timeCreated": "2023-01-03T07:05:54.999Z",                                                   |
|                             |         "fileSystemId": "ocid1.filesystem.oc1.iad.aaaaaaaaaabgxjyfnfqwillqojxwiotjmfsc2ylefuzqaaaa", |
|                             |         "lifecycleState": "ACTIVE"                                                                   |
|                             |     },                                                                                               |
|                             |     {                                                                                                |
|                             |         "id": "ocid1.export.oc1.iad.aaaaaa4np2t5xes5nfqwillqojxwiotjmfsc2ylefuzqaaaa",               |
|                             |         "path": "/FileSystem-20230103-0702-23",                                                      |
|                             |         "exportSetId": "ocid1.exportset.oc1.iad.aaaaacvippywrgaonfqwillqojxwiotjmfsc2ylefuzqaaaa",   |
|                             |         "timeCreated": "2023-01-03T07:02:34.301Z",                                                   |
|                             |         "fileSystemId": "ocid1.filesystem.oc1.iad.aaaaaaaaaabgxjyfnfqwillqojxwiotjmfsc2ylefuzqaaaa", |
|                             |         "lifecycleState": "ACTIVE"                                                                   |
|                             |     }                                                                                                |
|                             | ]                                                                                                    |
| FileSystem-20230103-0653-39 | [                                                                                                    |
|                             |     {                                                                                                |
|                             |         "id": "ocid1.export.oc1.iad.aaaaaa4np2t5xerxnfqwillqojxwiotjmfsc2ylefuzqaaaa",               |
|                             |         "path": "/FileSystem-20230103-0653-39",                                                      |
|                             |         "exportSetId": "ocid1.exportset.oc1.iad.aaaaacvippywrgaonfqwillqojxwiotjmfsc2ylefuzqaaaa",   |
|                             |         "timeCreated": "2023-01-03T06:54:05.329Z",                                                   |
|                             |         "fileSystemId": "ocid1.filesystem.oc1.iad.aaaaaaaaaabgxjvznfqwillqojxwiotjmfsc2ylefuzqaaaa", |
|                             |         "lifecycleState": "ACTIVE"                                                                   |
|                             |     }                                                                                                |
|                             | ]                                                                                                    |
+-----------------------------+------------------------------------------------------------------------------------------------------+
```
</details>
