### PR TITLE
Add table oci_core_cluster_network closes #449

### DIFF
--- a/docs/tables/oci_core_cluster_network.md
+++ b/docs/tables/oci_core_cluster_network.md
@@ -22,15 +22,15 @@ from
 select
   c.display_name,
   p -> 'availabilityDomains' as availability_domains,
-  p -> 'instanceConfigurationId' as instance_configuration_id,
-  p -> 'lifecycleState' as instance_pool_state,
-  p -> 'size' as instance_pool_size
+  p ->> 'instanceConfigurationId' as instance_configuration_id,
+  p ->> 'lifecycleState' as instance_pool_state,
+  p ->> 'size' as instance_pool_size
 from
   oci_core_cluster_network as c,
   jsonb_array_elements(instance_pools) as p;
 ```
 
-### List available cluster networks
+### List stopped cluster networks
 
 ```sql
 select
@@ -41,7 +41,7 @@ select
 from
   oci_core_cluster_network
 where
-  lifecycle_state = 'AVAIALABLE';
+  lifecycle_state = 'STOPPED';
 ```
 
 ### List cluster networks created in the last 30 days

--- a/docs/tables/oci_core_cluster_network.md
+++ b/docs/tables/oci_core_cluster_network.md
@@ -1,0 +1,59 @@
+# Table: oci_core_cluster_network
+
+A cluster network is a pool of high performance computing (HPC), GPU, or Optimized instances that are connected with a high-bandwidth, ultra low-latency network. Each node in the cluster is a bare metal machine located in close physical proximity to the other nodes. A remote direct memory access (RDMA) network between nodes provides latency as low as single-digit microseconds, comparable to on-premises HPC clusters.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  display_name,
+  id,
+  time_created,
+  lifecycle_state as state
+from
+  oci_core_cluster_network;
+```
+
+### Get instance pool details of cluster network
+
+```sql
+select
+  c.display_name,
+  p -> 'availabilityDomains' as availability_domains,
+  p -> 'instanceConfigurationId' as instance_configuration_id,
+  p -> 'lifecycleState' as instance_pool_state,
+  p -> 'size' as instance_pool_size
+from
+  oci_core_cluster_network as c,
+  jsonb_array_elements(instance_pools) as p;
+```
+
+### List available cluster networks
+
+```sql
+select
+  display_name,
+  id,
+  time_created,
+  lifecycle_state as state
+from
+  oci_core_cluster_network
+where
+  lifecycle_state = 'AVAIALABLE';
+```
+
+### Lis cluster networks created in last 30 days
+
+```sql
+select
+  display_name,
+  id,
+  time_created,
+  lifecycle_state as state
+from
+  oci_core_cluster_network
+where
+  time_created >= now() - interval '30' day;
+```

--- a/docs/tables/oci_core_cluster_network.md
+++ b/docs/tables/oci_core_cluster_network.md
@@ -44,7 +44,7 @@ where
   lifecycle_state = 'AVAIALABLE';
 ```
 
-### Lis cluster networks created in last 30 days
+### List cluster networks created in the last 30 days
 
 ```sql
 select

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -50,6 +50,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_core_boot_volume_metric_write_ops_daily":                  tableOciCoreBootVolumeMetricWriteOpsDaily(ctx),
 			"oci_core_boot_volume_metric_write_ops_hourly":                 tableOciCoreBootVolumeMetricWriteOpsHourly(ctx),
 			"oci_core_boot_volume_replica":                                 tableCoreBootVolumeReplica(ctx),
+			"oci_core_cluster_network":                                     tableCoreClusterNetwork(ctx),
 			"oci_core_dhcp_options":                                        tableCoreDhcpOptions(ctx),
 			"oci_core_drg":                                                 tableCoreDrg(ctx),
 			"oci_core_image":                                               tableCoreImage(ctx),

--- a/oci/service.go
+++ b/oci/service.go
@@ -799,7 +799,7 @@ func coreComputeService(ctx context.Context, d *plugin.QueryData, region string)
 	return sess, nil
 }
 
-// coreComputeService returns the service client for OCI Core Compute service
+// coreComputeManagementService returns the service client for OCI Core Compute service
 func coreComputeManagementService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
 	logger := plugin.Logger(ctx)
 

--- a/oci/service.go
+++ b/oci/service.go
@@ -57,6 +57,7 @@ type session struct {
 	BudgetClient                   budget.BudgetClient
 	CloudGuardClient               cloudguard.CloudGuardClient
 	ComputeClient                  core.ComputeClient
+	ComputeManagementClient        core.ComputeManagementClient
 	ContainerEngineClient          containerengine.ContainerEngineClient
 	DatabaseClient                 database.DatabaseClient
 	DnsClient                      dns.DnsClient
@@ -798,6 +799,48 @@ func coreComputeService(ctx context.Context, d *plugin.QueryData, region string)
 	return sess, nil
 }
 
+// coreComputeService returns the service client for OCI Core Compute service
+func coreComputeManagementService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
+	logger := plugin.Logger(ctx)
+
+	// have we already created and cached the service?
+	serviceCacheKey := fmt.Sprintf("computemanagement-%s", region)
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*session), nil
+	}
+
+	// get oci config info from steampipe connection
+	ociConfig := GetConfig(d.Connection)
+
+	provider, err := getProvider(ctx, d.ConnectionManager, region, ociConfig)
+	if err != nil {
+		logger.Error("coreComputeManagementService", "getProvider.Error", err)
+		return nil, err
+	}
+
+	// get compute service client
+	client, err := core.NewComputeManagementClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// get tenant ocid from provider
+	tenantId, err := provider.TenancyOCID()
+	if err != nil {
+		return nil, err
+	}
+
+	sess := &session{
+		TenancyID:     tenantId,
+		ComputeManagementClient: client,
+	}
+
+	// save session in cache
+	d.ConnectionManager.Cache.Set(serviceCacheKey, sess)
+
+	return sess, nil
+}
+
 // coreVirtualNetworkService returns the service client for OCI Core VirtualNetwork Service
 func coreVirtualNetworkService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
 	logger := plugin.Logger(ctx)
@@ -1493,12 +1536,14 @@ func getProvider(_ context.Context, d *connection.Manager, region string, config
 }
 
 /*
-	#  Configure the Oracle Cloud Infrastructure provider with an API Key / or a profile
+# Configure the Oracle Cloud Infrastructure provider with an API Key / or a profile
+
 	connection "oci" {
 		config_file_profile = "DEFAULT"
 		config_path = "~/Desktop/config"
 		regions = ["ap-mumbai-1", "us-ashburn-1"]
 	}
+
 	connection "oci" {
 		tenancy_ocid = "tenancy_ocid"
 		user_ocid = "user_ocid"
@@ -1562,7 +1607,8 @@ func getProviderForAPIkey(region string, config ociConfig) (oci_common.Configura
 }
 
 /*
-	# Provider for SecurityToken Authentication
+# Provider for SecurityToken Authentication
+
 	connection "oci" {
 		auth = "SecurityToken"
 		config_file_profile= "config_file_profile"
@@ -1593,6 +1639,7 @@ func getProviderForSecurityToken(region string, config ociConfig) (oci_common.Co
 
 /*
 # Provider for Instance Principal based authentication
+
 	connection "oci" {
 		plugin 		= "oci"
 		auth 			= "InstancePrincipal"

--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -39,7 +39,7 @@ func tableCoreClusterNetwork(_ context.Context) *plugin.Table {
 				},
 			},
 		},
-		GetMatrixItemFunc: BuildCompartementZonalList,
+		GetMatrixItemFunc: BuildCompartementRegionList,
 		Columns: []*plugin.Column{
 			{
 				Name:        "id",

--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -132,9 +132,7 @@ func tableCoreClusterNetwork(_ context.Context) *plugin.Table {
 func listClusterNetworks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
-	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
-	logger.Debug("oci_core_cluster_network.listClusterNetworks", "Compartment", compartment, "OCI_Zone", zone)
 
 	equalQuals := d.KeyColumnQuals
 
@@ -146,7 +144,7 @@ func listClusterNetworks(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	// Create Session
 	session, err := coreComputeManagementService(ctx, d, region)
 	if err != nil {
-		logger.Debug("oci_core_cluster_network.listClusterNetworks", "Compartment", compartment, "OCI_Zone", zone)
+		logger.Error("oci_core_cluster_network.ListClusterNetworks", "connection_error", err)
 		return nil, err
 	}
 
@@ -177,6 +175,7 @@ func listClusterNetworks(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	for pagesLeft {
 		response, err := session.ComputeManagementClient.ListClusterNetworks(ctx, request)
 		if err != nil {
+			logger.Error("oci_core_cluster_network.ListClusterNetworks", "api_error", err)
 			return nil, err
 		}
 
@@ -205,7 +204,6 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
 	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
-	logger.Debug("oci_core_cluster_network.getClusterNetwork", "Compartment", compartment, "OCI_zone", zone)
 
 	// Restrict the api call to only root compartment and one zone/ per region
 	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
@@ -222,7 +220,7 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	// Create Session
 	session, err := coreComputeManagementService(ctx, d, region)
 	if err != nil {
-		logger.Debug("oci_core_cluster_network.getClusterNetwork", "Compartment", compartment, "OCI_Zone", zone)
+		logger.Error("oci_core_cluster_network.getClusterNetwork", "connection_error", err)
 		return nil, err
 	}
 
@@ -235,6 +233,7 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 
 	response, err := session.ComputeManagementClient.GetClusterNetwork(ctx, request)
 	if err != nil {
+		logger.Error("oci_core_cluster_network.getClusterNetwork", "api_error", err)
 		return nil, err
 	}
 

--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -1,0 +1,263 @@
+package oci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableCoreClusterNetwork(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_core_cluster_network",
+		Description: "OCI Core Cluster Network",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getClusterNetwork,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listClusterNetworks,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "compartment_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "volume_group_id",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: BuildCompartementZonalList,
+		Columns: []*plugin.Column{
+			{
+				Name:        "id",
+				Description: "The OCID of the cluster network.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "display_name",
+				Description: "A user-friendly name. Does not have to be unique, and it's changeable. Avoid entering confidential information.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "lifecycle_state",
+				Description: "The current state of the cluster network.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "time_created",
+				Description: "The date and time the resource was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+			{
+				Name:        "time_updated",
+				Description: "The date and time the resource was updated.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeUpdated.Time"),
+			},
+
+			// json fields
+			{
+				Name:        "instance_pools",
+				Description: "The instance pools in the cluster network.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// tags
+			{
+				Name:        "defined_tags",
+				Description: ColumnDescriptionDefinedTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "freeform_tags",
+				Description: ColumnDescriptionFreefromTags,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Standard Steampipe columns
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(clusterNetworkTags),
+			},
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DisplayName"),
+			},
+
+			// Standard OCI columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Id").Transform(ociRegionName),
+			},
+			{
+				Name:        "compartment_id",
+				Description: ColumnDescriptionCompartment,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CompartmentId"),
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenant,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listClusterNetworks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
+	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	logger.Debug("oci_core_cluster_network.listClusterNetworks", "Compartment", compartment, "OCI_Zone", zone)
+
+	equalQuals := d.KeyColumnQuals
+
+	// Return nil, if given compartment_id doesn't match
+	if equalQuals["compartment_id"] != nil && compartment != equalQuals["compartment_id"].GetStringValue() {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := coreComputeManagementService(ctx, d, region)
+	if err != nil {
+		logger.Debug("oci_core_cluster_network.listClusterNetworks", "Compartment", compartment, "OCI_Zone", zone)
+		return nil, err
+	}
+
+	request := core.ListClusterNetworksRequest{
+		CompartmentId:      types.String(compartment),
+		Limit:              types.Int(1000),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := session.ComputeManagementClient.ListClusterNetworks(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, computeManagement := range response.Items {
+			d.StreamListItem(ctx, computeManagement)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.OpcNextPage != nil {
+			request.Page = response.OpcNextPage
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTION
+
+func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
+	zone := plugin.GetMatrixItem(ctx)[matrixKeyZone].(string)
+	compartment := plugin.GetMatrixItem(ctx)[matrixKeyCompartment].(string)
+	logger.Debug("oci_core_cluster_network.getClusterNetwork", "Compartment", compartment, "OCI_zone", zone)
+
+	// Restrict the api call to only root compartment and one zone/ per region
+	if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") || !strings.HasSuffix(zone, "AD-1") {
+		return nil, nil
+	}
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+
+	// handle empty cluster network id in get call
+	if strings.TrimSpace(id) == "" {
+		return nil, nil
+	}
+
+		// Create Session
+	session, err := coreComputeManagementService(ctx, d, region)
+	if err != nil {
+		logger.Debug("oci_core_cluster_network.getClusterNetwork", "Compartment", compartment, "OCI_Zone", zone)
+		return nil, err
+	}
+
+
+	request := core.GetClusterNetworkRequest{
+		ClusterNetworkId: types.String(id),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	response, err := session.ComputeManagementClient.GetClusterNetwork(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+//// TRANSFORM FUNCTION
+
+// Priority order for tags
+// 1. System Tags
+// 2. Defined Tags
+// 3. Free-form tags
+func clusterNetworkTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	clusterNetwork := d.HydrateItem.(core.ClusterNetworkSummary)
+
+	var tags map[string]interface{}
+
+	if clusterNetwork.FreeformTags != nil {
+		tags = map[string]interface{}{}
+		for k, v := range clusterNetwork.FreeformTags {
+			tags[k] = v
+		}
+	}
+
+	if clusterNetwork.DefinedTags != nil {
+		if tags == nil {
+			tags = map[string]interface{}{}
+		}
+		for _, v := range clusterNetwork.DefinedTags {
+			for key, value := range v {
+				tags[key] = value
+			}
+
+		}
+	}
+
+	return tags, nil
+}

--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -233,6 +233,9 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 
 	response, err := session.ComputeManagementClient.GetClusterNetwork(ctx, request)
 	if err != nil {
+		if strings.Contains(err.Error(), "InvalidParameter") {
+			return nil, nil
+		}
 		logger.Error("oci_core_cluster_network.getClusterNetwork", "api_error", err)
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from oci_core_cluster_network
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------
| id                                                                                                | display_name                  | lifecycle_state | time_created              | time_updated              | instance_pools                                                
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------
| ocid1.clusternetwork.oc1.ap-mumbai-1.amaaaaaa6igdexaay55ef4foqlogh6fa52zd556rbyfznpoknbfp6enblbvq | cluster-network-20230111-2100 | PROVISIONING    | 2023-01-11T21:00:39+05:30 | 2023-01-11T21:02:12+05:30 | [{"availabilityDomains":["TvRS:AP-MUMBAI-1-AD-1"],"compartment
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------

Time: 6.7s. Rows fetched: 1. Hydrate calls: 1.
> .cache off
> .cache clear
> select * from oci_core_cluster_network where display_name = 'cluster-network-20230111-2100'
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------
| id                                                                                                | display_name                  | lifecycle_state | time_created              | time_updated              | instance_pools                                                
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------
| ocid1.clusternetwork.oc1.ap-mumbai-1.amaaaaaa6igdexaay55ef4foqlogh6fa52zd556rbyfznpoknbfp6enblbvq | cluster-network-20230111-2100 | PROVISIONING    | 2023-01-11T21:00:39+05:30 | 2023-01-11T21:02:12+05:30 | [{"availabilityDomains":["TvRS:AP-MUMBAI-1-AD-1"],"compartment
+---------------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------------------------------------------------------


```
</details>
