### PR TITLE
Add table oci_core_volume_default_backup_policy closes #462

### DIFF
--- a/docs/tables/oci_core_volume_default_backup_policy.md
+++ b/docs/tables/oci_core_volume_default_backup_policy.md
@@ -2,7 +2,7 @@
 
 The Oracle Cloud Infrastructure Block Volume service provides you with the capability to perform volume backups and volume group backups automatically on a schedule and retain them based on the selected backup policy.
 
-There are three Oracle defined backup policies, Bronze, Silver, and Gold. Each backup policy is comprised of schedules with a set backup frequency and a retention period that you cannot modify.Oracle defined backup policies are not supported for scheduled volume group backups.
+There are three Oracle defined backup policies: `Bronze`, `Silver`, and `Gold`. Each backup policy is comprised of schedules with a set backup frequency and a retention period that you cannot modify. Oracle defined backup policies are not supported for scheduled volume group backups.
 
 ## Examples
 

--- a/docs/tables/oci_core_volume_default_backup_policy.md
+++ b/docs/tables/oci_core_volume_default_backup_policy.md
@@ -1,6 +1,8 @@
 # Table: oci_core_volume_default_backup_policy
 
-A policy for automatically creating volume backups according to a recurring schedule. Has a set of one or more schedules that control when and how backups are created.
+The Oracle Cloud Infrastructure Block Volume service provides you with the capability to perform volume backups and volume group backups automatically on a schedule and retain them based on the selected backup policy.
+
+There are three Oracle defined backup policies, Bronze, Silver, and Gold. Each backup policy is comprised of schedules with a set backup frequency and a retention period that you cannot modify.Oracle defined backup policies are not supported for scheduled volume group backups.
 
 ## Examples
 
@@ -10,20 +12,7 @@ A policy for automatically creating volume backups according to a recurring sche
 select
   id,
   display_name,
-  time_created,
-  region,
-  tags
-from
-  oci_core_volume_default_backup_policy;
-```
-
-### Get the destination region for each volume backup policy
-
-```sql
-select
-  id,
-  display_name,
-  destination_region
+  time_created
 from
   oci_core_volume_default_backup_policy;
 ```
@@ -36,29 +25,12 @@ select
   display_name,
   s ->> 'backupType' as backup_type,
   s ->> 'dayOfMonth' as day_of_month,
-  s ->> 'dayOfWeek' as day_of_week,
   s ->> 'hourOfDay' as hour_of_day,
-  s ->> 'month' as month,
-  s ->> 'offsetSeconds' as offset_econds,
-  s ->> 'offsetType' as offset_type,
-  s ->> 'period' as offset_econds,
+  s ->> 'offsetSeconds' as offset_seconds,
+  s ->> 'period' as period,
   s ->> 'retentionSeconds' as retention_seconds,
   s ->> 'timeZone' as time_zone
 from
   oci_core_volume_default_backup_policy,
   jsonb_array_elements(schedules) as s;
-```
-
-### List volume back policies that create full backups
-
-```sql
-select
-  id,
-  display_name,
-  s ->> 'backupType' as backup_type
-from
-  oci_core_volume_default_backup_policy,
-  jsonb_array_elements(schedules) as s
-where
-  s ->> 'backupType' = 'FULL';
 ```

--- a/docs/tables/oci_core_volume_default_backup_policy.md
+++ b/docs/tables/oci_core_volume_default_backup_policy.md
@@ -1,0 +1,64 @@
+# Table: oci_core_volume_default_backup_policy
+
+A policy for automatically creating volume backups according to a recurring schedule. Has a set of one or more schedules that control when and how backups are created.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  id,
+  display_name,
+  time_created,
+  region,
+  tags
+from
+  oci_core_volume_default_backup_policy;
+```
+
+### Get the destination region for each volume backup policy
+
+```sql
+select
+  id,
+  display_name,
+  destination_region
+from
+  oci_core_volume_default_backup_policy;
+```
+
+### Get schedule info for each volume backup policy
+
+```sql
+select
+  id,
+  display_name,
+  s ->> 'backupType' as backup_type,
+  s ->> 'dayOfMonth' as day_of_month,
+  s ->> 'dayOfWeek' as day_of_week,
+  s ->> 'hourOfDay' as hour_of_day,
+  s ->> 'month' as month,
+  s ->> 'offsetSeconds' as offset_econds,
+  s ->> 'offsetType' as offset_type,
+  s ->> 'period' as offset_econds,
+  s ->> 'retentionSeconds' as retention_seconds,
+  s ->> 'timeZone' as time_zone
+from
+  oci_core_volume_default_backup_policy,
+  jsonb_array_elements(schedules) as s;
+```
+
+### List volume back policies that create full backups
+
+```sql
+select
+  id,
+  display_name,
+  s ->> 'backupType' as backup_type
+from
+  oci_core_volume_default_backup_policy,
+  jsonb_array_elements(schedules) as s
+where
+  s ->> 'backupType' = 'FULL';
+```

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -76,6 +76,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_core_volume_attachment":                                   tableCoreVolumeAttachment(ctx),
 			"oci_core_volume_backup":                                       tableCoreVolumeBackup(ctx),
 			"oci_core_volume_backup_policy":                                tableCoreVolumeBackupPolicy(ctx),
+			"oci_core_volume_default_backup_policy":                        tableCoreVolumeDefaultBackupPolicy(ctx),
 			"oci_database_autonomous_database":                             tableOciDatabaseAutonomousDatabase(ctx),
 			"oci_database_autonomous_db_metric_cpu_utilization":            tableOciDatabaseAutonomousDatabaseMetricCpuUtilization(ctx),
 			"oci_database_autonomous_db_metric_cpu_utilization_daily":      tableOciDatabaseAutonomousDatabaseMetricCpuUtilizationDaily(ctx),

--- a/oci/table_oci_core_volume_default_backup_policy.go
+++ b/oci/table_oci_core_volume_default_backup_policy.go
@@ -43,14 +43,6 @@ func tableCoreVolumeDefaultBackupPolicy(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("TimeCreated.Time"),
 			},
 
-			// other columns
-
-			{
-				Name:        "destination_region",
-				Description: "The paired destination region for copying scheduled backups to.",
-				Type:        proto.ColumnType_STRING,
-			},
-
 			// json fields
 			{
 				Name:        "schedules",
@@ -58,25 +50,7 @@ func tableCoreVolumeDefaultBackupPolicy(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 
-			// tags
-			{
-				Name:        "defined_tags",
-				Description: ColumnDescriptionDefinedTags,
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "freeform_tags",
-				Description: ColumnDescriptionFreefromTags,
-				Type:        proto.ColumnType_JSON,
-			},
-
 			// Standard Steampipe columns
-			{
-				Name:        "tags",
-				Description: ColumnDescriptionTags,
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(volumeDefaultBackupPolicyTags),
-			},
 			{
 				Name:        "title",
 				Description: ColumnDescriptionTitle,
@@ -85,18 +59,6 @@ func tableCoreVolumeDefaultBackupPolicy(_ context.Context) *plugin.Table {
 			},
 
 			// Standard OCI columns
-			{
-				Name:        "region",
-				Description: ColumnDescriptionRegion,
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Id").Transform(ociRegionName),
-			},
-			{
-				Name:        "compartment_id",
-				Description: ColumnDescriptionCompartment,
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("CompartmentId"),
-			},
 			{
 				Name:        "tenant_id",
 				Description: ColumnDescriptionTenant,
@@ -120,7 +82,6 @@ func listCoreVolumeDefaultBackupPolicies(ctx context.Context, d *plugin.QueryDat
 	}
 
 	request := core.ListVolumeBackupPoliciesRequest{
-		Limit: types.Int(1000),
 		RequestMetadata: common.RequestMetadata{
 			RetryPolicy: getDefaultRetryPolicy(d.Connection),
 		},
@@ -193,37 +154,4 @@ func getCoreVolumeDefaultBackupPolicy(ctx context.Context, d *plugin.QueryData, 
 	}
 
 	return response.VolumeBackupPolicy, nil
-}
-
-//// TRANSFORM FUNCTION
-
-// Priority order for tags
-// 1. Free-form tags
-// 2. Defined Tags
-
-func volumeDefaultBackupPolicyTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	volumeBackupPolicy := d.HydrateItem.(core.VolumeBackupPolicy)
-
-	var tags map[string]interface{}
-
-	if volumeBackupPolicy.FreeformTags != nil {
-		tags = map[string]interface{}{}
-		for k, v := range volumeBackupPolicy.FreeformTags {
-			tags[k] = v
-		}
-	}
-
-	if volumeBackupPolicy.DefinedTags != nil {
-		if tags == nil {
-			tags = map[string]interface{}{}
-		}
-		for _, v := range volumeBackupPolicy.DefinedTags {
-			for key, value := range v {
-				tags[key] = value
-			}
-
-		}
-	}
-
-	return tags, nil
 }

--- a/oci/table_oci_core_volume_default_backup_policy.go
+++ b/oci/table_oci_core_volume_default_backup_policy.go
@@ -1,0 +1,229 @@
+package oci
+
+import (
+	"context"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/core"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableCoreVolumeDefaultBackupPolicy(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "oci_core_volume_default_backup_policy",
+		Description: "OCI Core Volume Default Backup Policy",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getCoreVolumeDefaultBackupPolicy,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listCoreVolumeDefaultBackupPolicies,
+		},
+		Columns: []*plugin.Column{
+			{
+				Name:        "display_name",
+				Description: "A user-friendly name for volume backup policy.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "id",
+				Description: "The OCID of the volume backup policy.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromCamel(),
+			},
+			{
+				Name:        "time_created",
+				Description: "The date and time the volume backup policy was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+
+			// other columns
+
+			{
+				Name:        "destination_region",
+				Description: "The paired destination region for copying scheduled backups to.",
+				Type:        proto.ColumnType_STRING,
+			},
+
+			// json fields
+			{
+				Name:        "schedules",
+				Description: "The collection of schedules that this policy will apply.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// tags
+			{
+				Name:        "defined_tags",
+				Description: ColumnDescriptionDefinedTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "freeform_tags",
+				Description: ColumnDescriptionFreefromTags,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Standard Steampipe columns
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(volumeDefaultBackupPolicyTags),
+			},
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DisplayName"),
+			},
+
+			// Standard OCI columns
+			{
+				Name:        "region",
+				Description: ColumnDescriptionRegion,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Id").Transform(ociRegionName),
+			},
+			{
+				Name:        "compartment_id",
+				Description: ColumnDescriptionCompartment,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CompartmentId"),
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenant,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listCoreVolumeDefaultBackupPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	// Create Session
+	session, err := coreBlockStorageService(ctx, d, "")
+	if err != nil {
+		logger.Error("oci_core_volume_default_backup_policy.listCoreVolumeDefaultBackupPolicies", "connection_error", err)
+		return nil, err
+	}
+
+	request := core.ListVolumeBackupPoliciesRequest{
+		Limit: types.Int(1000),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	// Check for limit
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := session.BlockstorageClient.ListVolumeBackupPolicies(ctx, request)
+		if err != nil {
+			logger.Error("oci_core_volume_default_backup_policy.listCoreVolumeDefaultBackupPolicies", "api_error", err)
+			return nil, err
+		}
+
+		for _, volumes := range response.Items {
+			d.StreamListItem(ctx, volumes)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.OpcNextPage != nil {
+			request.Page = response.OpcNextPage
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTION
+
+func getCoreVolumeDefaultBackupPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+
+	id := d.KeyColumnQuals["id"].GetStringValue()
+
+	// handle empty volume backup policy id in get call
+	if id == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := coreBlockStorageService(ctx, d, "")
+	if err != nil {
+		logger.Error("oci_core_volume_default_backup_policy.getCoreVolumeDefaultBackupPolicy", "connection_error", err)
+		return nil, err
+	}
+
+	request := core.GetVolumeBackupPolicyRequest{
+		PolicyId: types.String(id),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	response, err := session.BlockstorageClient.GetVolumeBackupPolicy(ctx, request)
+	if err != nil {
+		logger.Error("oci_core_volume_default_backup_policy.getCoreVolumeDefaultBackupPolicy", "api_error", err)
+		return nil, err
+	}
+
+	return response.VolumeBackupPolicy, nil
+}
+
+//// TRANSFORM FUNCTION
+
+// Priority order for tags
+// 1. Free-form tags
+// 2. Defined Tags
+
+func volumeDefaultBackupPolicyTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	volumeBackupPolicy := d.HydrateItem.(core.VolumeBackupPolicy)
+
+	var tags map[string]interface{}
+
+	if volumeBackupPolicy.FreeformTags != nil {
+		tags = map[string]interface{}{}
+		for k, v := range volumeBackupPolicy.FreeformTags {
+			tags[k] = v
+		}
+	}
+
+	if volumeBackupPolicy.DefinedTags != nil {
+		if tags == nil {
+			tags = map[string]interface{}{}
+		}
+		for _, v := range volumeBackupPolicy.DefinedTags {
+			for key, value := range v {
+				tags[key] = value
+			}
+
+		}
+	}
+
+	return tags, nil
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  id,
  display_name,
  time_created,
  region,
  tags
from
  oci_core_volume_default_backup_policy;
+--------------------------------------------------------------------------------------------+--------------+---------------------------+--------+------+
| id                                                                                         | display_name | time_created              | region | tags |
+--------------------------------------------------------------------------------------------+--------------+---------------------------+--------+------+
| ocid1.volumebackuppolicy.oc1..aaaaaaaa7hwv7iscewqqcmyqe2zuzfce6setvckhbxduswtxf6ctew7e54ja | silver       | 2017-10-01T05:30:00+05:30 |        | {}   |
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | 2017-10-01T05:30:00+05:30 |        | {}   |
| ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q | bronze       | 2017-10-01T05:30:00+05:30 |        | {}   |
+--------------------------------------------------------------------------------------------+--------------+---------------------------+--------+------+

Time: 415ms. Rows fetched: 3. Hydrate calls: 0.

> select
  id,
  display_name,
  destination_region
from
  oci_core_volume_default_backup_policy;
+--------------------------------------------------------------------------------------------+--------------+--------------------+
| id                                                                                         | display_name | destination_region |
+--------------------------------------------------------------------------------------------+--------------+--------------------+
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | <null>             |
| ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q | bronze       | <null>             |
| ocid1.volumebackuppolicy.oc1..aaaaaaaa7hwv7iscewqqcmyqe2zuzfce6setvckhbxduswtxf6ctew7e54ja | silver       | <null>             |
+--------------------------------------------------------------------------------------------+--------------+--------------------+

Time: 188ms. Rows fetched: 3. Hydrate calls: 0.
> select
  id,
  display_name,
  s ->> 'backupType' as backup_type,
  s ->> 'dayOfMonth' as day_of_month,
  s ->> 'hourOfDay' as hour_of_day,
  s ->> 'offsetSeconds' as offset_seconds,
  s ->> 'period' as period,
  s ->> 'retentionSeconds' as retention_seconds,
  s ->> 'timeZone' as time_zone
from
  oci_core_volume_default_backup_policy,
  jsonb_array_elements(schedules) as s;
+--------------------------------------------------------------------------------------------+--------------+-------------+--------------+-------------+----------------+-----------+-------------------+---------------------------+
| id                                                                                         | display_name | backup_type | day_of_month | hour_of_day | offset_seconds | period    | retention_seconds | time_zone                 |
+--------------------------------------------------------------------------------------------+--------------+-------------+--------------+-------------+----------------+-----------+-------------------+---------------------------+
| ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q | bronze       | INCREMENTAL | <null>       | <null>      | 0              | ONE_MONTH | 31557600          | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q | bronze       | INCREMENTAL | <null>       | <null>      | 0              | ONE_YEAR  | 157680000         | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | INCREMENTAL | <null>       | <null>      | 0              | ONE_DAY   | 604800            | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | INCREMENTAL | <null>       | <null>      | 0              | ONE_WEEK  | 2419200           | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | INCREMENTAL | <null>       | <null>      | 0              | ONE_MONTH | 31557600          | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaagcremuefit7dpcnjpdrtphjk4bwm3emm55t6cghctt2m6iyyjdva | gold         | INCREMENTAL | <null>       | <null>      | 0              | ONE_YEAR  | 157680000         | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaa7hwv7iscewqqcmyqe2zuzfce6setvckhbxduswtxf6ctew7e54ja | silver       | INCREMENTAL | <null>       | <null>      | 0              | ONE_WEEK  | 2419200           | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaa7hwv7iscewqqcmyqe2zuzfce6setvckhbxduswtxf6ctew7e54ja | silver       | INCREMENTAL | <null>       | <null>      | 0              | ONE_MONTH | 31557600          | REGIONAL_DATA_CENTER_TIME |
| ocid1.volumebackuppolicy.oc1..aaaaaaaa7hwv7iscewqqcmyqe2zuzfce6setvckhbxduswtxf6ctew7e54ja | silver       | INCREMENTAL | <null>       | <null>      | 0              | ONE_YEAR  | 157680000         | REGIONAL_DATA_CENTER_TIME |
+--------------------------------------------------------------------------------------------+--------------+-------------+--------------+-------------+----------------+-----------+-------------------+---------------------------+
> select * from oci_core_volume_default_backup_policy where id = 'ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q'
+--------------+--------------------------------------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------------------------------------------
| display_name | id                                                                                         | time_created              | destination_region | schedules                                                                                                        
+--------------+--------------------------------------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------------------------------------------
| bronze       | ocid1.volumebackuppolicy.oc1..aaaaaaaadrzfwjb5tflixtmy5axp2kx65uqakgnupfogabzjhtn5x5dfra6q | 2017-10-01T05:30:00+05:30 | <null>             | [{"backupType":"INCREMENTAL","dayOfMonth":null,"hourOfDay":null,"offsetSeconds":0,"period":"ONE_MONTH","retention
+--------------+--------------------------------------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------------------------------------------
```
</details>
