### PR TITLE
Add KmsKeyId, VaultId ,KmsKeyVersionId column in table oci_database_autonomous_database closes #468

### DIFF
--- a/docs/tables/oci_database_autonomous_database.md
+++ b/docs/tables/oci_database_autonomous_database.md
@@ -48,3 +48,39 @@ from
 where
   data_storage_size_in_gbs > 1024;
 ```
+
+### Get KMS key details for the databases
+
+```sql
+select
+  d.db_name,
+  d.display_name,
+  d.kms_key_id,
+  k.name as key_name,
+  k.algorithm as key_algorithm,
+  k.current_key_version,
+  k.protection_mode
+from
+  oci_database_autonomous_database as d,
+  oci_kms_key as k
+where
+  k.id = d.kms_key_id;
+```
+
+### Get KMS vault details for the databases
+
+```sql
+select
+  d.db_name,
+  d.display_name,
+  d.vault_id,
+  v.display_name as vault_display_name,
+  v.crypto_endpoint,
+  v.vault_type,
+  v.management_endpoint
+from
+  oci_database_autonomous_database as d,
+  oci_kms_vault as v
+where
+  v.id = d.vault_id;
+```

--- a/oci/table_oci_database_autonomous_database.go
+++ b/oci/table_oci_database_autonomous_database.go
@@ -198,11 +198,13 @@ func tableOciDatabaseAutonomousDatabase(_ context.Context) *plugin.Table {
 				Name:        "kms_key_id",
 				Description: "The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KmsKeyId"),
 			},
 			{
 				Name:        "kms_key_version_id",
 				Description: "The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KmsKeyVersionId"),
 			},
 			{
 				Name:        "lifecycle_details",
@@ -340,6 +342,7 @@ func tableOciDatabaseAutonomousDatabase(_ context.Context) *plugin.Table {
 				Name:        "vault_id",
 				Description: "The OCID of the Oracle Cloud Infrastructure vault.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("VaultId"),
 			},
 			{
 				Name:        "apex_details",

--- a/oci/table_oci_database_autonomous_database.go
+++ b/oci/table_oci_database_autonomous_database.go
@@ -195,6 +195,16 @@ func tableOciDatabaseAutonomousDatabase(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "kms_key_id",
+				Description: "The OCID of the key container that is used as the master encryption key in database transparent data encryption (TDE) operations.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "kms_key_version_id",
+				Description: "The OCID of the key container version that is used in database transparent data encryption (TDE) operations KMS Key can have multiple key versions.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "lifecycle_details",
 				Description: "Information about the current lifecycle state.",
 				Type:        proto.ColumnType_STRING,
@@ -325,6 +335,11 @@ func tableOciDatabaseAutonomousDatabase(_ context.Context) *plugin.Table {
 				Description: "The amount of storage that has been used, in terabytes.",
 				Type:        proto.ColumnType_INT,
 				Transform:   transform.FromField("UsedDataStorageSizeInTBs"),
+			},
+			{
+				Name:        "VaultId",
+				Description: "The OCID of the Oracle Cloud Infrastructure vault.",
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "apex_details",

--- a/oci/table_oci_database_autonomous_database.go
+++ b/oci/table_oci_database_autonomous_database.go
@@ -337,7 +337,7 @@ func tableOciDatabaseAutonomousDatabase(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("UsedDataStorageSizeInTBs"),
 			},
 			{
-				Name:        "VaultId",
+				Name:        "vault_id",
 				Description: "The OCID of the Oracle Cloud Infrastructure vault.",
 				Type:        proto.ColumnType_STRING,
 			},


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Test names: [ 'tests/oci_database_autonomous_database' ]
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging

SETUP: tests/oci_database_autonomous_database []

PRETEST: tests/oci_database_autonomous_database

TEST: tests/oci_database_autonomous_database
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # oci_database_autonomous_database.named_test_resource will be created
  + resource "oci_database_autonomous_database" "named_test_resource" {
      + actual_used_data_storage_size_in_tbs           = (known after apply)
      + admin_password                                 = (sensitive value)
      + allocated_storage_size_in_tbs                  = (known after apply)
      + apex_details                                   = (known after apply)
      + are_primary_whitelisted_ips_used               = (known after apply)
      + autonomous_container_database_id               = (known after apply)
      + autonomous_database_backup_id                  = (known after apply)
      + autonomous_database_id                         = (known after apply)
      + autonomous_maintenance_schedule_type           = (known after apply)
      + available_upgrade_versions                     = (known after apply)
      + backup_config                                  = (known after apply)
      + character_set                                  = (known after apply)
      + clone_type                                     = (known after apply)
      + compartment_id                                 = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5ssdadfsasadajnjqmfkr4po3hoz4psdadfsasadaa"
      + connection_strings                             = (known after apply)
      + connection_urls                                = (known after apply)
      + cpu_core_count                                 = 1
      + data_safe_status                               = (known after apply)
      + data_storage_size_in_gb                        = (known after apply)
      + data_storage_size_in_tbs                       = 1
      + database_edition                               = (known after apply)
      + database_management_status                     = (known after apply)
      + dataguard_region_type                          = (known after apply)
      + db_name                                        = "dbTest"
      + db_version                                     = (known after apply)
      + db_workload                                    = (known after apply)
      + defined_tags                                   = (known after apply)
      + display_name                                   = "steampipetest4553"
      + failed_data_recovery_in_seconds                = (known after apply)
      + freeform_tags                                  = (known after apply)
      + id                                             = (known after apply)
      + infrastructure_type                            = (known after apply)
      + is_access_control_enabled                      = (known after apply)
      + is_auto_scaling_enabled                        = (known after apply)
      + is_auto_scaling_for_storage_enabled            = (known after apply)
      + is_data_guard_enabled                          = (known after apply)
      + is_dedicated                                   = (known after apply)
      + is_free_tier                                   = (known after apply)
      + is_local_data_guard_enabled                    = (known after apply)
      + is_mtls_connection_required                    = (known after apply)
      + is_preview                                     = (known after apply)
      + is_preview_version_with_service_terms_accepted = (known after apply)
      + is_reconnect_clone_enabled                     = (known after apply)
      + is_refreshable_clone                           = (known after apply)
      + is_remote_data_guard_enabled                   = (known after apply)
      + key_history_entry                              = (known after apply)
      + key_store_id                                   = (known after apply)
      + key_store_wallet_name                          = (known after apply)
      + kms_key_id                                     = (known after apply)
      + kms_key_lifecycle_details                      = (known after apply)
      + kms_key_version_id                             = (known after apply)
      + license_model                                  = (known after apply)
      + lifecycle_details                              = (known after apply)
      + local_standby_db                               = (known after apply)
      + max_cpu_core_count                             = (known after apply)
      + memory_per_oracle_compute_unit_in_gbs          = (known after apply)
      + ncharacter_set                                 = (known after apply)
      + nsg_ids                                        = (known after apply)
      + ocpu_count                                     = (known after apply)
      + open_mode                                      = (known after apply)
      + operations_insights_status                     = (known after apply)
      + peer_db_ids                                    = (known after apply)
      + permission_level                               = (known after apply)
      + private_endpoint                               = (known after apply)
      + private_endpoint_ip                            = (known after apply)
      + private_endpoint_label                         = (known after apply)
      + provisionable_cpus                             = (known after apply)
      + refreshable_mode                               = (known after apply)
      + refreshable_status                             = (known after apply)
      + role                                           = (known after apply)
      + service_console_url                            = (known after apply)
      + source                                         = (known after apply)
      + source_id                                      = (known after apply)
      + standby_db                                     = (known after apply)
      + standby_whitelisted_ips                        = (known after apply)
      + state                                          = (known after apply)
      + subnet_id                                      = (known after apply)
      + supported_regions_to_clone_to                  = (known after apply)
      + system_tags                                    = (known after apply)
      + time_created                                   = (known after apply)
      + time_data_guard_role_changed                   = (known after apply)
      + time_deletion_of_free_autonomous_database      = (known after apply)
      + time_local_data_guard_enabled                  = (known after apply)
      + time_maintenance_begin                         = (known after apply)
      + time_maintenance_end                           = (known after apply)
      + time_of_last_failover                          = (known after apply)
      + time_of_last_refresh                           = (known after apply)
      + time_of_last_refresh_point                     = (known after apply)
      + time_of_last_switchover                        = (known after apply)
      + time_of_next_refresh                           = (known after apply)
      + time_reclamation_of_free_autonomous_database   = (known after apply)
      + time_until_reconnect_clone_enabled             = (known after apply)
      + timestamp                                      = (known after apply)
      + use_latest_available_backup_time_stamp         = (known after apply)
      + used_data_storage_size_in_tbs                  = (known after apply)
      + vault_id                                       = (known after apply)

      + customer_contacts {
          + email = (known after apply)
        }

      + scheduled_operations {
          + scheduled_start_time = (known after apply)
          + scheduled_stop_time  = (known after apply)

          + day_of_week {
              + name = (known after apply)
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + db_name       = "dbTest"
  + resource_id   = (known after apply)
  + resource_name = "steampipetest4553"
  + tenancy_ocid  = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5ssdadfsasadajnjqmfkr4po3hoz4psdadfsasadaa"
oci_database_autonomous_database.named_test_resource: Creating...
oci_database_autonomous_database.named_test_resource: Still creating... [10s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [20s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [30s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [40s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [50s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [1m0s elapsed]
oci_database_autonomous_database.named_test_resource: Still creating... [1m10s elapsed]
oci_database_autonomous_database.named_test_resource: Creation complete after 1m14s [id=ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaatv3gfhdkmum7khcrz6ojm7u2mpi4qv2orxlenixt76ja]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

db_name = "dbTest"
resource_id = "ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaatv3gfhdkmum7khcrz6ojm7u2mpi4qv2orxlenixt76ja"
resource_name = "steampipetest4553"
tenancy_ocid = "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5ssdadfsasadajnjqmfkr4po3hoz4psdadfsasadaa"

Running SQL query: test-get-query.sql

[
  {
    "db_name": "dbTest",
    "id": "ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaatv3gfhdkmum7khcrz6ojm7u2mpi4qv2orxlenixt76ja",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

[
  {
    "db_name": "dbTest",
    "id": "ocid1.autonomousdatabase.oc1.ap-mumbai-1.anrg6ljr6igdexaatv3gfhdkmum7khcrz6ojm7u2mpi4qv2orxlenixt76ja",
    "lifecycle_state": "AVAILABLE"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

null
✔ PASSED

Running SQL query: test-turbot-query.sql

[
  {
    "tenant_id": "ocid1.tenancy.oc1..aaaaaaaahnm7gleh5ssdadfsasadajnjqmfkr4po3hoz4psdadfsasadaa",
    "title": "steampipetest4553"
  }
]
✔ PASSED

POSTTEST: tests/oci_database_autonomous_database

TEARDOWN: tests/oci_database_autonomous_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  d.db_name,
  d.display_name,
  d.kms_key_id,
  k.name as key_name,
  k.algorithm as key_algorithm,
  k.current_key_version,
  k.protection_mode
from
  oci_database_autonomous_database as d,
  oci_kms_key as k
where
  k.id = d.kms_key_id;
+------------------+---------------------+------------------------------------------------------------------------------------------------------+----------+---------------+--------------------------------------------------------------------------------------------------
| db_name          | display_name        | kms_key_id                                                                                           | key_name | key_algorithm | current_key_version                                                                              
+------------------+---------------------+------------------------------------------------------------------------------------------------------+----------+---------------+--------------------------------------------------------------------------------------------------
| XSKSPPAOY8VV0UJA | XSKSPPAOY8VV0UJA    | ocid1.key.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrsu4bwufbeqsith3uvdkidjapmr76idu56qxwrrftuvlnbuv3f4ea | tet      | AES           | ocid1.keyversion.oc1.ap-mumbai-1.cvrvcqk4aaft4.dseempipypiaa.abrg6ljrhu2o2bhphnbxadl5dfy2yuipwuw7
| DBRM             | RM-BEZ6UR5QHL9KNJ7M | ocid1.key.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrsu4bwufbeqsith3uvdkidjapmr76idu56qxwrrftuvlnbuv3f4ea | tet      | AES           | ocid1.keyversion.oc1.ap-mumbai-1.cvrvcqk4aaft4.dseempipypiaa.abrg6ljrhu2o2bhphnbxadl5dfy2yuipwuw7
| ZTCFSTG2HLTTOCO2 | ZTCFSTG2HLTTOCO2    | ocid1.key.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrsu4bwufbeqsith3uvdkidjapmr76idu56qxwrrftuvlnbuv3f4ea | tet      | AES           | ocid1.keyversion.oc1.ap-mumbai-1.cvrvcqk4aaft4.dseempipypiaa.abrg6ljrhu2o2bhphnbxadl5dfy2yuipwuw7
| RARB7U9LC9VY226Y | RARB7U9LC9VY2ddd    | ocid1.key.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrsu4bwufbeqsith3uvdkidjapmr76idu56qxwrrftuvlnbuv3f4ea | tet      | AES           | ocid1.keyversion.oc1.ap-mumbai-1.cvrvcqk4aaft4.dseempipypiaa.abrg6ljrhu2o2bhphnbxadl5dfy2yuipwuw7
| J6OP60FN92QYF7E1 | J6OP60FN92QYF7E1    | ocid1.key.oc1.iad.b5r3ieizaaew2.abuwcljrysgzfdh74z3z43geskf5j7vrtk6i6encvyeihs2np5xp566f2iqq         | key-1    | AES           | ocid1.keyversion.oc1.iad.b5r3ieizaaew2.awelmphfrdqaa.abuwcljrpu7lzdzh4cudzj43jf3ubcgryr2crxrc7rfe
| JLVY9H13J1XXC5C9 | JLVY9H13J1XXC5C9    | ocid1.key.oc1.iad.b5r3ieizaaew2.abuwcljrysgzfdh74z3z43geskf5j7vrtk6i6encvyeihs2np5xp566f2iqq         | key-1    | AES           | ocid1.keyversion.oc1.iad.b5r3ieizaaew2.awelmphfrdqaa.abuwcljrpu7lzdzh4cudzj43jf3ubcgryr2crxrc7rfe
+------------------+---------------------+------------------------------------------------------------------------------------------------------+----------+---------------+--------------------------------------------------------------------------------------------------

Time: 6731.9ms. Rows fetched: 17. Hydrate calls: 11.
> select
  d.db_name,
  d.display_name,
  d.vault_id,
  v.display_name as vault_display_name,
  v.crypto_endpoint,
  v.vault_type,
  v.management_endpoint
from
  oci_database_autonomous_database as d,
  oci_kms_vault as v
where
  v.id = d.vault_id;
+------------------+---------------------+--------------------------------------------------------------------------------------------------------+--------------------+---------------------------------------------------------------+------------+-------------------------
| db_name          | display_name        | vault_id                                                                                               | vault_display_name | crypto_endpoint                                               | vault_type | management_endpoint     
+------------------+---------------------+--------------------------------------------------------------------------------------------------------+--------------------+---------------------------------------------------------------+------------+-------------------------
| XSKSPPAOY8VV0UJA | XSKSPPAOY8VV0UJA    | ocid1.vault.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrx6xzmb2zibe2jgselifxl6irkkeblhvhhk6bhsun34nrc7znydhq | test-graph         | https://cvrvcqk4aaft4-crypto.kms.ap-mumbai-1.oraclecloud.com  | DEFAULT    | https://cvrvcqk4aaft4-ma
| DBRM             | RM-BEZ6UR5QHL9KNJ7M | ocid1.vault.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrx6xzmb2zibe2jgselifxl6irkkeblhvhhk6bhsun34nrc7znydhq | test-graph         | https://cvrvcqk4aaft4-crypto.kms.ap-mumbai-1.oraclecloud.com  | DEFAULT    | https://cvrvcqk4aaft4-ma
| RARB7U9LC9VY226Y | RARB7U9LC9VY2ddd    | ocid1.vault.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrx6xzmb2zibe2jgselifxl6irkkeblhvhhk6bhsun34nrc7znydhq | test-graph         | https://cvrvcqk4aaft4-crypto.kms.ap-mumbai-1.oraclecloud.com  | DEFAULT    | https://cvrvcqk4aaft4-ma
| ZTCFSTG2HLTTOCO2 | ZTCFSTG2HLTTOCO2    | ocid1.vault.oc1.ap-mumbai-1.cvrvcqk4aaft4.abrg6ljrx6xzmb2zibe2jgselifxl6irkkeblhvhhk6bhsun34nrc7znydhq | test-graph         | https://cvrvcqk4aaft4-crypto.kms.ap-mumbai-1.oraclecloud.com  | DEFAULT    | https://cvrvcqk4aaft4-ma
| JLVY9H13J1XXC5C9 | JLVY9H13J1XXC5C9    | ocid1.vault.oc1.iad.b5r3ieizaaew2.abuwcljtc2qcyk3xjccjnix3iy5qxowtlbqbadsbygzdgus35pxvs4s3xpnq         | ks-vault           | https://b5r3ieizaaew2-crypto.kms.us-ashburn-1.oraclecloud.com | DEFAULT    | https://b5r3ieizaaew2-ma
| J6OP60FN92QYF7E1 | J6OP60FN92QYF7E1    | ocid1.vault.oc1.iad.b5r3ieizaaew2.abuwcljtc2qcyk3xjccjnix3iy5qxowtlbqbadsbygzdgus35pxvs4s3xpnq         | ks-vault           | https://b5r3ieizaaew2-crypto.kms.us-ashburn-1.oraclecloud.com | DEFAULT    | https://b5r3ieizaaew2-ma
+------------------+---------------------+--------------------------------------------------------------------------------------------------------+--------------------+---------------------------------------------------------------+------------+-------------------------


```
</details>
