### PR TITLE
Fix region issue in get call in oci_core_cluster_network table

### DIFF
--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/oracle/oci-go-sdk/v65/common"
-	oci_common "github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
@@ -215,10 +214,10 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 
 	// For the us-phoenix-1 and us-ashburn-1 regions, `phx` and `iad` are returned by ListInstances api, respectively.
 	// For all other regions, the full region name is returned.
-	region := oci_common.StringToRegion(types.SafeString(strings.Split(id, ".")[3]))
+	region := common.StringToRegion(types.SafeString(strings.Split(id, ".")[3]))
 
 	// handle empty id and region check in get call
-	if id == "" || region != oci_common.StringToRegion(matrixRegion) {
+	if id == "" || region != common.StringToRegion(matrixRegion) {
 		return nil, nil
 	}
 	logger.Error("region", region)

--- a/oci/table_oci_core_cluster_network.go
+++ b/oci/table_oci_core_cluster_network.go
@@ -220,7 +220,7 @@ func getClusterNetwork(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 	if id == "" || region != common.StringToRegion(matrixRegion) {
 		return nil, nil
 	}
-	logger.Error("region", region)
+
 	// Create Session
 	session, err := coreComputeManagementService(ctx, d, matrixRegion)
 	if err != nil {


### PR DESCRIPTION
```
> select * from oci_core_cluster_network where id = 'ocid1.clusternetwork.oc1.iad.amaaaaaa6igdexaayu2bq7n4rrcplupo6gbb3ly2qtlrykhxl3lzpctsfi4a'
+-------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------
| id                                                                                        | display_name                  | lifecycle_state | time_created              | time_updated              | instance_pools
+-------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------
| ocid1.clusternetwork.oc1.iad.amaaaaaa6igdexaayu2bq7n4rrcplupo6gbb3ly2qtlrykhxl3lzpctsfi4a | cluster-network-20230127-1632 | TERMINATED      | 2023-01-27T16:32:57+05:30 | 2023-01-27T16:33:05+05:30 | []            
+-------------------------------------------------------------------------------------------+-------------------------------+-----------------+---------------------------+---------------------------+---------------

```
</details>
