### PR TITLE
Fix typo and formatting of log messages in oci_queue_queue table

### DIFF
--- a/docs/tables/oci_queue_queue.md
+++ b/docs/tables/oci_queue_queue.md
@@ -44,7 +44,7 @@ where
   custom_encryption_key_id is null;
 ```  
 
-### Get details for each queue
+### Get details of each queue
 
 ```sql
 select

--- a/oci/table_oci_queue_queue.go
+++ b/oci/table_oci_queue_queue.go
@@ -186,7 +186,7 @@ func listQueues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	// Create Session
 	session, err := queueService(ctx, d, region)
 	if err != nil {
-                logger.Error("oci_queue_queue.listQueues", "connection_error", err)
+    logger.Error("oci_queue_queue.listQueues", "connection_error", err)
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func listQueues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	for pagesLeft {
 		response, err := session.QueueAdminClient.ListQueues(ctx, request)
 		if err != nil {
-                         logger.Error("oci_queue_queue.listQueues", "api_error", err)
+      logger.Error("oci_queue_queue.listQueues", "api_error", err)
 			return nil, err
 		}
 
@@ -260,7 +260,7 @@ func getQueue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 	// Create Session
 	session, err := queueService(ctx, d, region)
 	if err != nil {
-                logger.Error("oci_queue_queue.getQueue", "connection_error", err)
+    logger.Error("oci_queue_queue.getQueue", "connection_error", err)
 		return nil, err
 	}
 
@@ -272,7 +272,7 @@ func getQueue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 	}
 	response, err := session.QueueAdminClient.GetQueue(ctx, request)
 	if err != nil {
-                logger.Error("oci_queue_queue.getQueue", "api_error", err)
+    logger.Error("oci_queue_queue.getQueue", "api_error", err)
 		return nil, err
 	}
 
@@ -291,8 +291,8 @@ func buildQueueFilters(equalQuals plugin.KeyColumnEqualsQualMap, logger hclog.Lo
 }
 
 // Priority order for tags
-// 2. Defined Tags
-// 3. Free-form tags
+// 1. Defined Tags
+// 2. Free-form tags
 func queueTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	var freeFormTags map[string]string
 	var definedTags map[string]map[string]interface{}

--- a/oci/table_oci_queue_queue.go
+++ b/oci/table_oci_queue_queue.go
@@ -19,8 +19,8 @@ import (
 
 func tableQueueQueue(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "oci_queue_queue",
-		Description: "OCI Queue Queue",
+		Name:             "oci_queue_queue",
+		Description:      "OCI Queue Queue",
 		DefaultTransform: transform.FromCamel(),
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("id"),
@@ -186,7 +186,7 @@ func listQueues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	// Create Session
 	session, err := queueService(ctx, d, region)
 	if err != nil {
-    logger.Error("oci_queue_queue.listQueues", "connection_error", err)
+		logger.Error("oci_queue_queue.listQueues", "connection_error", err)
 		return nil, err
 	}
 
@@ -212,7 +212,7 @@ func listQueues(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData)
 	for pagesLeft {
 		response, err := session.QueueAdminClient.ListQueues(ctx, request)
 		if err != nil {
-      logger.Error("oci_queue_queue.listQueues", "api_error", err)
+			logger.Error("oci_queue_queue.listQueues", "api_error", err)
 			return nil, err
 		}
 
@@ -260,7 +260,7 @@ func getQueue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 	// Create Session
 	session, err := queueService(ctx, d, region)
 	if err != nil {
-    logger.Error("oci_queue_queue.getQueue", "connection_error", err)
+		logger.Error("oci_queue_queue.getQueue", "connection_error", err)
 		return nil, err
 	}
 
@@ -272,7 +272,7 @@ func getQueue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 	}
 	response, err := session.QueueAdminClient.GetQueue(ctx, request)
 	if err != nil {
-    logger.Error("oci_queue_queue.getQueue", "api_error", err)
+		logger.Error("oci_queue_queue.getQueue", "api_error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
