### PR TITLE
Add oci_network_firewall_firewall and oci_network_firewall_policy tables

### DIFF
--- a/docs/tables/oci_network_firewall_firewall.md
+++ b/docs/tables/oci_network_firewall_firewall.md
@@ -20,3 +20,55 @@ select
 from
   oci_network_firewall_firewall;
 ```
+
+### List network firewalls created in the last 30 days
+
+```sql
+select
+  id,
+  display_name,
+  availability_domain,
+  ipv4_address,
+  ipv6_address,
+  network_firewall_policy_id,
+  network_security_group_ids,
+  subnet_id,
+  lifecycle_state as state
+from
+  oci_network_firewall_firewall
+where
+  time_created >= now() - interval '30' day;
+```
+
+### List network firewalls having IPv6 address
+
+```sql
+select
+  id,
+  display_name,
+  availability_domain,
+  ipv4_address,
+  ipv6_address,
+  network_firewall_policy_id,
+  network_security_group_ids,
+  subnet_id,
+  lifecycle_state as state
+from
+  oci_network_firewall_firewall
+where
+  ipv6_address is not null;
+```
+
+### Describe the network firewall policy associated to the network firewall
+
+```sql
+select
+    f.display_name as firewall_name,
+    f.id as firewall_id,
+    p.display_name as policy_display_name,
+    p.id as policy_id,
+    p.lifecycle_details as policy_lifecycle
+from
+  oci_network_firewall_firewall as f
+  left join oci_network_firewall_policy as p on f.network_firewall_policy_id = p.id;
+```

--- a/docs/tables/oci_network_firewall_firewall.md
+++ b/docs/tables/oci_network_firewall_firewall.md
@@ -1,0 +1,22 @@
+# Table: oci_network_firewall_firewall
+
+A network firewall is a security resource that exists in a subnet of your choice and controls incoming and outgoing network traffic based on a set of security rules. Each firewall is associated with a policy. Traffic is routed to and from the firewall from resources such as internet gateways and dynamic routing gateways (DRGs).
+
+## Examples
+
+### Basic info
+
+```sql
+select
+    id,
+    display_name,
+    availability_domain,
+    ipv4_address,
+    ipv6_address,
+    network_firewall_policy_id,
+    network_security_group_ids,
+    subnet_id,
+    lifecycle_state as state
+from
+  oci_network_firewall_firewall;
+```

--- a/docs/tables/oci_network_firewall_firewall.md
+++ b/docs/tables/oci_network_firewall_firewall.md
@@ -8,15 +8,15 @@ A network firewall is a security resource that exists in a subnet of your choice
 
 ```sql
 select
-    id,
-    display_name,
-    availability_domain,
-    ipv4_address,
-    ipv6_address,
-    network_firewall_policy_id,
-    network_security_group_ids,
-    subnet_id,
-    lifecycle_state as state
+  id,
+  display_name,
+  availability_domain,
+  ipv4_address,
+  ipv6_address,
+  network_firewall_policy_id,
+  network_security_group_ids,
+  subnet_id,
+  lifecycle_state as state
 from
   oci_network_firewall_firewall;
 ```

--- a/docs/tables/oci_network_firewall_firewall.md
+++ b/docs/tables/oci_network_firewall_firewall.md
@@ -63,12 +63,14 @@ where
 
 ```sql
 select
-    f.display_name as firewall_name,
-    f.id as firewall_id,
-    p.display_name as policy_display_name,
-    p.id as policy_id,
-    p.lifecycle_details as policy_lifecycle
+  f.display_name as firewall_name,
+  f.id as firewall_id,
+  p.display_name as policy_display_name,
+  p.id as policy_id,
+  p.lifecycle_details as policy_lifecycle 
 from
-  oci_network_firewall_firewall as f
-  left join oci_network_firewall_policy as p on f.network_firewall_policy_id = p.id;
+  oci_network_firewall_firewall as f 
+  left join
+    oci_network_firewall_policy as p 
+    on f.network_firewall_policy_id = p.id;
 ```

--- a/docs/tables/oci_network_firewall_policy.md
+++ b/docs/tables/oci_network_firewall_policy.md
@@ -1,0 +1,24 @@
+# Table: oci_network_firewall_policy
+
+A network firewall policy is attached to a network firewall.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+    id,
+    display_name,
+    application_lists,
+    decryption_profiles,
+    decryption_rules,
+    ip_address_lists,
+    is_firewall_attached,
+    mapped_secrets,
+    security_rules,
+    url_lists,
+    lifecycle_state as state
+from
+  oci_network_firewall_policy;
+```

--- a/docs/tables/oci_network_firewall_policy.md
+++ b/docs/tables/oci_network_firewall_policy.md
@@ -8,17 +8,80 @@ A network firewall policy is attached to a network firewall.
 
 ```sql
 select
-    id,
-    display_name,
-    application_lists,
-    decryption_profiles,
-    decryption_rules,
-    ip_address_lists,
-    is_firewall_attached,
-    mapped_secrets,
-    security_rules,
-    url_lists,
-    lifecycle_state as state
+  id,
+  display_name,
+  jsonb_pretty(application_lists) as application_lists,
+  jsonb_pretty(decryption_profiles) as decryption_profiles,
+  jsonb_pretty(decryption_rules) as decryption_rules,
+  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  is_firewall_attached,
+  jsonb_pretty(mapped_secrets) as mapped_secrets,
+  jsonb_pretty(security_rules) as security_rules,
+  jsonb_pretty(url_lists) as url_lists,
+  lifecycle_state as state
 from
   oci_network_firewall_policy;
+```
+
+### List network firewall policies created in the last 30 days
+
+```sql
+select
+  id,
+  display_name,
+  jsonb_pretty(application_lists) as application_lists,
+  jsonb_pretty(decryption_profiles) as decryption_profiles,
+  jsonb_pretty(decryption_rules) as decryption_rules,
+  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  is_firewall_attached,
+  jsonb_pretty(mapped_secrets) as mapped_secrets,
+  jsonb_pretty(security_rules) as security_rules,
+  jsonb_pretty(url_lists) as url_lists,
+  lifecycle_state as state
+from
+  oci_network_firewall_policy
+where
+  time_created >= now() - interval '30' day;
+```
+
+### List network firewall policies with firewall attached
+
+```sql
+select
+  id,
+  display_name,
+  jsonb_pretty(application_lists) as application_lists,
+  jsonb_pretty(decryption_profiles) as decryption_profiles,
+  jsonb_pretty(decryption_rules) as decryption_rules,
+  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  is_firewall_attached,
+  jsonb_pretty(mapped_secrets) as mapped_secrets,
+  jsonb_pretty(security_rules) as security_rules,
+  jsonb_pretty(url_lists) as url_lists,
+  lifecycle_state as state
+from
+  oci_network_firewall_policy
+where
+  is_firewall_attached;
+```
+
+### List network firewall policies without mapped secrets
+
+```sql
+select
+  id,
+  display_name,
+  jsonb_pretty(application_lists) as application_lists,
+  jsonb_pretty(decryption_profiles) as decryption_profiles,
+  jsonb_pretty(decryption_rules) as decryption_rules,
+  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  is_firewall_attached,
+  jsonb_pretty(mapped_secrets) as mapped_secrets,
+  jsonb_pretty(security_rules) as security_rules,
+  jsonb_pretty(url_lists) as url_lists,
+  lifecycle_state as state
+from
+  oci_network_firewall_policy
+where
+  mapped_secrets is null;
 ```

--- a/docs/tables/oci_network_firewall_policy.md
+++ b/docs/tables/oci_network_firewall_policy.md
@@ -10,14 +10,14 @@ A network firewall policy is attached to a network firewall.
 select
   id,
   display_name,
-  jsonb_pretty(application_lists) as application_lists,
-  jsonb_pretty(decryption_profiles) as decryption_profiles,
-  jsonb_pretty(decryption_rules) as decryption_rules,
-  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  application_lists,
+  decryption_profiles,
+  decryption_rules,
+  ip_address_lists,
   is_firewall_attached,
-  jsonb_pretty(mapped_secrets) as mapped_secrets,
-  jsonb_pretty(security_rules) as security_rules,
-  jsonb_pretty(url_lists) as url_lists,
+  mapped_secrets,
+  security_rules,
+  url_lists,
   lifecycle_state as state
 from
   oci_network_firewall_policy;
@@ -29,14 +29,14 @@ from
 select
   id,
   display_name,
-  jsonb_pretty(application_lists) as application_lists,
-  jsonb_pretty(decryption_profiles) as decryption_profiles,
-  jsonb_pretty(decryption_rules) as decryption_rules,
-  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  application_lists,
+  decryption_profiles,
+  decryption_rules,
+  ip_address_lists,
   is_firewall_attached,
-  jsonb_pretty(mapped_secrets) as mapped_secrets,
-  jsonb_pretty(security_rules) as security_rules,
-  jsonb_pretty(url_lists) as url_lists,
+  mapped_secrets,
+  security_rules,
+  url_lists,
   lifecycle_state as state
 from
   oci_network_firewall_policy
@@ -50,14 +50,14 @@ where
 select
   id,
   display_name,
-  jsonb_pretty(application_lists) as application_lists,
-  jsonb_pretty(decryption_profiles) as decryption_profiles,
-  jsonb_pretty(decryption_rules) as decryption_rules,
-  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  application_lists,
+  decryption_profiles,
+  decryption_rules,
+  ip_address_lists,
   is_firewall_attached,
-  jsonb_pretty(mapped_secrets) as mapped_secrets,
-  jsonb_pretty(security_rules) as security_rules,
-  jsonb_pretty(url_lists) as url_lists,
+  mapped_secrets,
+  security_rules,
+  url_lists,
   lifecycle_state as state
 from
   oci_network_firewall_policy
@@ -71,14 +71,14 @@ where
 select
   id,
   display_name,
-  jsonb_pretty(application_lists) as application_lists,
-  jsonb_pretty(decryption_profiles) as decryption_profiles,
-  jsonb_pretty(decryption_rules) as decryption_rules,
-  jsonb_pretty(ip_address_lists) as ip_address_lists,
+  application_lists,
+  decryption_profiles,
+  decryption_rules,
+  ip_address_lists,
   is_firewall_attached,
-  jsonb_pretty(mapped_secrets) as mapped_secrets,
-  jsonb_pretty(security_rules) as security_rules,
-  jsonb_pretty(url_lists) as url_lists,
+  mapped_secrets,
+  security_rules,
+  url_lists,
   lifecycle_state as state
 from
   oci_network_firewall_policy

--- a/oci/plugin.go
+++ b/oci/plugin.go
@@ -136,6 +136,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"oci_mysql_db_system_metric_memory_utilization":                tableOciMySQLDBSystemMetricMemoryUtilization(ctx),
 			"oci_mysql_db_system_metric_memory_utilization_daily":          tableOciMySQLDBSystemMetricMemoryUtilizationDaily(ctx),
 			"oci_mysql_heat_wave_cluster":                                  tableOciMySQLHeatWaveCluster(ctx),
+			"oci_network_firewall_firewall":                                tableNetworkFirewall(ctx),
+			"oci_network_firewall_policy":                                  tableNetworkFirewallPolicy(ctx),
 			"oci_nosql_table":                                              tableNoSQLTable(ctx),
 			"oci_nosql_table_metric_read_throttle_count":                   tableOciNoSQLTableMetricReadThrottleCount(ctx),
 			"oci_nosql_table_metric_read_throttle_count_daily":             tableOciNoSQLTableMetricReadThrottleCountDaily(ctx),

--- a/oci/service.go
+++ b/oci/service.go
@@ -35,6 +35,7 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/logging"
 	"github.com/oracle/oci-go-sdk/v65/monitoring"
 	"github.com/oracle/oci-go-sdk/v65/mysql"
+	"github.com/oracle/oci-go-sdk/v65/networkfirewall"
 	"github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
 	"github.com/oracle/oci-go-sdk/v65/nosql"
 	"github.com/oracle/oci-go-sdk/v65/objectstorage"
@@ -70,21 +71,22 @@ type session struct {
 	IdentityClient                 identity.IdentityClient
 	KmsManagementClient            keymanagement.KmsManagementClient
 	KmsVaultClient                 keymanagement.KmsVaultClient
-	LoggingManagementClient        logging.LoggingManagementClient
 	LoadBalancerClient             loadbalancer.LoadBalancerClient
+	LoggingManagementClient        logging.LoggingManagementClient
 	MonitoringClient               monitoring.MonitoringClient
-	MySQLConfigurationClient       mysql.MysqlaasClient
-	MySQLChannelClient             mysql.ChannelsClient
 	MySQLBackupClient              mysql.DbBackupsClient
+	MySQLChannelClient             mysql.ChannelsClient
+	MySQLConfigurationClient       mysql.MysqlaasClient
 	MySQLDBSystemClient            mysql.DbSystemClient
+	NetworkFirewallClient          networkfirewall.NetworkFirewallClient
 	NetworkLoadBalancerClient      networkloadbalancer.NetworkLoadBalancerClient
 	NoSQLClient                    nosql.NosqlClient
 	NotificationControlPlaneClient ons.NotificationControlPlaneClient
 	NotificationDataPlaneClient    ons.NotificationDataPlaneClient
 	ObjectStorageClient            objectstorage.ObjectStorageClient
 	QueueAdminClient               queue.QueueAdminClient
-	ResourceSearchClient           resourcesearch.ResourceSearchClient
 	ResourceManagerClient          resourcemanager.ResourceManagerClient
+	ResourceSearchClient           resourcesearch.ResourceSearchClient
 	StreamAdminClient              streaming.StreamAdminClient
 	VaultClient                    vault.VaultsClient
 	VirtualNetworkClient           core.VirtualNetworkClient
@@ -521,6 +523,48 @@ func functionsManagementService(ctx context.Context, d *plugin.QueryData, region
 	sess := &session{
 		TenancyID:                 tenantID,
 		FunctionsManagementClient: client,
+	}
+
+	// save session in cache
+	d.ConnectionManager.Cache.Set(serviceCacheKey, sess)
+
+	return sess, nil
+}
+
+// networkService returns the service client for OCI Network Firewall service
+func networkFirewallService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
+	logger := plugin.Logger(ctx)
+
+	// have we already created and cached the service?
+	serviceCacheKey := fmt.Sprintf("networkFirewall-%s", region)
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*session), nil
+	}
+
+	// get oci config info from steampipe connection
+	ociConfig := GetConfig(d.Connection)
+
+	provider, err := getProvider(ctx, d.ConnectionManager, region, ociConfig)
+	if err != nil {
+		logger.Error("networkFirewallService", "getProvider.Error", err)
+		return nil, err
+	}
+
+	// get network firewall service client
+	client, err := networkfirewall.NewNetworkFirewallClientWithConfigurationProvider(provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// get tenant ocid from provider
+	tenantId, err := provider.TenancyOCID()
+	if err != nil {
+		return nil, err
+	}
+
+	sess := &session{
+		TenancyID:             tenantId,
+		NetworkFirewallClient: client,
 	}
 
 	// save session in cache
@@ -1338,7 +1382,6 @@ func queueService(ctx context.Context, d *plugin.QueryData, region string) (*ses
 	return sess, nil
 }
 
-
 // resourceSearchService returns the service client for OCI Resource Search Service
 func resourceSearchService(ctx context.Context, d *plugin.QueryData, region string) (*session, error) {
 	logger := plugin.Logger(ctx)
@@ -1564,8 +1607,8 @@ func bastionService(ctx context.Context, d *plugin.QueryData, region string) (*s
 	}
 
 	sess := &session{
-		TenancyID:       tenantId,
-		BastionClient:   client,
+		TenancyID:     tenantId,
+		BastionClient: client,
 	}
 
 	// save session in cache

--- a/oci/table_oci_network_firewall_firewall.go
+++ b/oci/table_oci_network_firewall_firewall.go
@@ -91,7 +91,7 @@ func tableNetworkFirewall(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "network_firewall_policy_id",
-				Description: "The OCID of the Network Firewall.",
+				Description: "The OCID of the Network Firewall Policy.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/oci/table_oci_network_firewall_firewall.go
+++ b/oci/table_oci_network_firewall_firewall.go
@@ -1,0 +1,325 @@
+package oci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/networkfirewall"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableNetworkFirewall(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:             "oci_network_firewall_firewall",
+		Description:      "OCI Network Firewall",
+		DefaultTransform: transform.FromCamel(),
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getNetworkFirewall,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listNetworkFirewalls,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "compartment_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "display_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "network_firewall_policy_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "availability_domain",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "lifecycle_state",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: BuildCompartementRegionList,
+		Columns: []*plugin.Column{
+			{
+				Name:        "id",
+				Description: "The OCID of the Network Firewall resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "availability_domain",
+				Description: "A filter to return only resources that are present within the specified availability domain.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "display_name",
+				Description: "A user-friendly name for the Network Firewall.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "ipv4_address",
+				Description: "IPv4 address for the Network Firewall.",
+				Type:        proto.ColumnType_IPADDR,
+			},
+			{
+				Name:        "ipv6_address",
+				Description: "IPv6 address for the Network Firewall.",
+				Type:        proto.ColumnType_IPADDR,
+			},
+			{
+				Name:        "lifecycle_details",
+				Description: "A message describing the current state in more detail.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "lifecycle_state",
+				Description: "The current state of the Network Firewall.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "network_firewall_policy_id",
+				Description: "The OCID of the Network Firewall.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "network_security_group_ids",
+				Description: "An array of network security groups OCID associated with the Network Firewall.",
+				Hydrate:     getNetworkFirewall,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "subnet_id",
+				Description: "The OCID of the subnet associated with the Network Firewall.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "time_created",
+				Description: "Time that Network Firewall was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+
+			// tags
+			{
+				Name:        "defined_tags",
+				Description: ColumnDescriptionDefinedTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "freeform_tags",
+				Description: ColumnDescriptionFreefromTags,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Standard Steampipe columns
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(networkFirewallTags),
+			},
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DisplayName"),
+			},
+
+			// Standard OCI columns
+			{
+				Name:        "compartment_id",
+				Description: ColumnDescriptionCompartment,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CompartmentId"),
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenantId,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listNetworkFirewalls(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := d.EqualsQualString(matrixKeyRegion)
+	compartment := d.EqualsQualString(matrixKeyCompartment)
+	logger.Debug("listNetworkFirewalls", "Compartment", compartment, "OCI_REGION", region)
+
+	equalQuals := d.EqualsQuals
+
+	// Return nil, if given compartment_id doesn't match
+	if equalQuals["compartment_id"] != nil && compartment != equalQuals["compartment_id"].GetStringValue() {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := networkFirewallService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	//Build request parameters
+	request := buildNetworkFirewallFilters(equalQuals)
+	request.CompartmentId = types.String(compartment)
+	request.Limit = types.Int(100)
+	request.RequestMetadata = common.RequestMetadata{
+		RetryPolicy: getDefaultRetryPolicy(d.Connection),
+	}
+
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := session.NetworkFirewallClient.ListNetworkFirewalls(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		for _, firewall := range response.Items {
+			d.StreamListItem(ctx, firewall)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.OpcNextPage != nil {
+			request.Page = response.OpcNextPage
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTION
+
+func getNetworkFirewall(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := d.EqualsQualString(matrixKeyRegion)
+	compartment := d.EqualsQualString(matrixKeyCompartment)
+	logger.Debug("getNetworkFirewall", "Compartment", compartment, "OCI_REGION", region)
+
+	var id string
+	if h.Item != nil {
+		id = *h.Item.(networkfirewall.NetworkFirewallSummary).Id
+	} else {
+		id = d.EqualsQuals["id"].GetStringValue()
+		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+			return nil, nil
+		}
+	}
+
+	// handle empty id in get call
+	if id == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := networkFirewallService(ctx, d, region)
+	if err != nil {
+		logger.Error("getNetworkFirewall", "error_NetworkFirewallService", err)
+		return nil, err
+	}
+
+	request := networkfirewall.GetNetworkFirewallRequest{
+		NetworkFirewallId: types.String(id),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	response, err := session.NetworkFirewallClient.GetNetworkFirewall(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return response.NetworkFirewall, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func networkFirewallTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	var freeformTags map[string]string
+	var definedTags map[string]map[string]interface{}
+
+	switch d.HydrateItem.(type) {
+	case networkfirewall.NetworkFirewall:
+		firewall := d.HydrateItem.(networkfirewall.NetworkFirewall)
+		freeformTags = firewall.FreeformTags
+		definedTags = firewall.DefinedTags
+	case networkfirewall.NetworkFirewallSummary:
+		firewall := d.HydrateItem.(networkfirewall.NetworkFirewallSummary)
+		freeformTags = firewall.FreeformTags
+		definedTags = firewall.DefinedTags
+	}
+
+	var tags map[string]interface{}
+
+	if freeformTags != nil {
+		tags = map[string]interface{}{}
+		for k, v := range freeformTags {
+			tags[k] = v
+		}
+	}
+
+	if definedTags != nil {
+		if tags == nil {
+			tags = map[string]interface{}{}
+		}
+		for _, v := range definedTags {
+			for key, value := range v {
+				tags[key] = value
+			}
+
+		}
+	}
+
+	return tags, nil
+}
+
+// Build additional filters
+func buildNetworkFirewallFilters(equalQuals plugin.KeyColumnEqualsQualMap) networkfirewall.ListNetworkFirewallsRequest {
+	request := networkfirewall.ListNetworkFirewallsRequest{}
+
+	if equalQuals["display_name"] != nil {
+		request.DisplayName = types.String(equalQuals["display_name"].GetStringValue())
+	}
+	if equalQuals["network_firewall_policy_id"] != nil {
+		request.NetworkFirewallPolicyId = types.String(equalQuals["network_firewall_policy_id"].GetStringValue())
+	}
+	if equalQuals["id"] != nil {
+		request.Id = types.String(equalQuals["id"].GetStringValue())
+	}
+	if equalQuals["availability_domain"] != nil {
+		request.AvailabilityDomain = types.String(equalQuals["availability_domain"].GetStringValue())
+	}
+	if equalQuals["lifecycle_state"] != nil {
+		request.LifecycleState = networkfirewall.ListNetworkFirewallsLifecycleStateEnum(equalQuals["lifecycle_state"].GetStringValue())
+	}
+
+	return request
+}

--- a/oci/table_oci_network_firewall_policy.go
+++ b/oci/table_oci_network_firewall_policy.go
@@ -1,0 +1,328 @@
+package oci
+
+import (
+	"context"
+	"strings"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	"github.com/oracle/oci-go-sdk/v65/networkfirewall"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableNetworkFirewallPolicy(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:             "oci_network_firewall_policy",
+		Description:      "OCI Network Firewall Policy",
+		DefaultTransform: transform.FromCamel(),
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getNetworkFirewallPolicy,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listNetworkFirewallPolicies,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "compartment_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "display_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "lifecycle_state",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: BuildCompartementRegionList,
+		Columns: []*plugin.Column{
+			{
+				Name:        "id",
+				Description: "The OCID of the Network Firewall Policy resource.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "display_name",
+				Description: "A user-friendly name for the Network Firewall Policy.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "application_lists",
+				Description: "A mapping of strings to arrays of Application objects.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "decryption_profiles",
+				Description: "A mapping of strings to DecryptionProfile objects.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "decryption_rules",
+				Description: "List of Decryption Rules defining the behavior of the policy. The first rule with a matching condition determines the action taken upon network traffic.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "ip_address_lists",
+				Description: "Map defining IP address lists of the policy. The value of an entry is a list of IP addresses or prefixes in CIDR notation. The associated key is the identifier by which the IP address list is referenced.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "is_firewall_attached",
+				Description: "To determine if any Network Firewall is associated with this Network Firewall Policy.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "lifecycle_details",
+				Description: "A message describing the current state in more detail.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "lifecycle_state",
+				Description: "The current state of the Network Firewall.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "mapped_secrets",
+				Description: "A mapping of strings to MappedSecret objects.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "security_rules",
+				Description: "List of Security Rules defining the behavior of the policy. The first rule with a matching condition determines the action taken upon network traffic.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "url_lists",
+				Description: "A mapping of strings to arrays of UrlPattern objects.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getNetworkFirewallPolicy,
+			},
+			{
+				Name:        "time_created",
+				Description: "Time that Network Firewall Policy was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("TimeCreated.Time"),
+			},
+
+			// tags
+			{
+				Name:        "defined_tags",
+				Description: ColumnDescriptionDefinedTags,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "freeform_tags",
+				Description: ColumnDescriptionFreefromTags,
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Standard Steampipe columns
+			{
+				Name:        "tags",
+				Description: ColumnDescriptionTags,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(networkFirewallPolicyTags),
+			},
+			{
+				Name:        "title",
+				Description: ColumnDescriptionTitle,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DisplayName"),
+			},
+
+			// Standard OCI columns
+			{
+				Name:        "compartment_id",
+				Description: ColumnDescriptionCompartment,
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CompartmentId"),
+			},
+			{
+				Name:        "tenant_id",
+				Description: ColumnDescriptionTenantId,
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     plugin.HydrateFunc(getTenantId).WithCache(),
+				Transform:   transform.FromValue(),
+			},
+		},
+	}
+}
+
+//// LIST FUNCTION
+
+func listNetworkFirewallPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := d.EqualsQualString(matrixKeyRegion)
+	compartment := d.EqualsQualString(matrixKeyCompartment)
+	logger.Debug("listNetworkFirewallPolicies", "Compartment", compartment, "OCI_REGION", region)
+
+	equalQuals := d.EqualsQuals
+
+	// Return nil, if given compartment_id doesn't match
+	if equalQuals["compartment_id"] != nil && compartment != equalQuals["compartment_id"].GetStringValue() {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := networkFirewallService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	//Build request parameters
+	request := buildNetworkFirewallPolicyFilters(equalQuals)
+	request.CompartmentId = types.String(compartment)
+	request.Limit = types.Int(100)
+	request.RequestMetadata = common.RequestMetadata{
+		RetryPolicy: getDefaultRetryPolicy(d.Connection),
+	}
+
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(*request.Limit) {
+			request.Limit = types.Int(int(*limit))
+		}
+	}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := session.NetworkFirewallClient.ListNetworkFirewallPolicies(ctx, request)
+		if err != nil {
+			return nil, err
+		}
+		for _, firewallPolicy := range response.Items {
+			d.StreamListItem(ctx, firewallPolicy)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.OpcNextPage != nil {
+			request.Page = response.OpcNextPage
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTION
+
+func getNetworkFirewallPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	region := d.EqualsQualString(matrixKeyRegion)
+	compartment := d.EqualsQualString(matrixKeyCompartment)
+	logger.Debug("getNetworkFirewallPolicy", "Compartment", compartment, "OCI_REGION", region)
+
+	var id string
+	if h.Item != nil {
+		id = *h.Item.(networkfirewall.NetworkFirewallPolicySummary).Id
+	} else {
+		id = d.EqualsQuals["id"].GetStringValue()
+		if !strings.HasPrefix(compartment, "ocid1.tenancy.oc1") {
+			return nil, nil
+		}
+	}
+
+	// handle empty id in get call
+	if id == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	session, err := networkFirewallService(ctx, d, region)
+	if err != nil {
+		logger.Error("getNetworkFirewallPolicy", "error_NetworkFirewallService", err)
+		return nil, err
+	}
+
+	request := networkfirewall.GetNetworkFirewallPolicyRequest{
+		NetworkFirewallPolicyId: types.String(id),
+		RequestMetadata: common.RequestMetadata{
+			RetryPolicy: getDefaultRetryPolicy(d.Connection),
+		},
+	}
+
+	response, err := session.NetworkFirewallClient.GetNetworkFirewallPolicy(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	return response.NetworkFirewallPolicy, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func networkFirewallPolicyTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	var freeformTags map[string]string
+	var definedTags map[string]map[string]interface{}
+
+	switch d.HydrateItem.(type) {
+	case networkfirewall.NetworkFirewallPolicy:
+		firewallPolicy := d.HydrateItem.(networkfirewall.NetworkFirewallPolicy)
+		freeformTags = firewallPolicy.FreeformTags
+		definedTags = firewallPolicy.DefinedTags
+	case networkfirewall.NetworkFirewallPolicySummary:
+		firewallPolicy := d.HydrateItem.(networkfirewall.NetworkFirewallPolicySummary)
+		freeformTags = firewallPolicy.FreeformTags
+		definedTags = firewallPolicy.DefinedTags
+	}
+
+	var tags map[string]interface{}
+
+	if freeformTags != nil {
+		tags = map[string]interface{}{}
+		for k, v := range freeformTags {
+			tags[k] = v
+		}
+	}
+
+	if definedTags != nil {
+		if tags == nil {
+			tags = map[string]interface{}{}
+		}
+		for _, v := range definedTags {
+			for key, value := range v {
+				tags[key] = value
+			}
+
+		}
+	}
+
+	return tags, nil
+}
+
+// Build additional filters
+func buildNetworkFirewallPolicyFilters(equalQuals plugin.KeyColumnEqualsQualMap) networkfirewall.ListNetworkFirewallPoliciesRequest {
+	request := networkfirewall.ListNetworkFirewallPoliciesRequest{}
+
+	if equalQuals["display_name"] != nil {
+		request.DisplayName = types.String(equalQuals["display_name"].GetStringValue())
+	}
+	if equalQuals["id"] != nil {
+		request.Id = types.String(equalQuals["id"].GetStringValue())
+	}
+	if equalQuals["lifecycle_state"] != nil {
+		request.LifecycleState = networkfirewall.ListNetworkFirewallPoliciesLifecycleStateEnum(equalQuals["lifecycle_state"].GetStringValue())
+	}
+
+	return request
+}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select
  id,
  display_name,
  availability_domain,
  ipv4_address,
  ipv6_address,
  network_firewall_policy_id,
  network_security_group_ids,
  subnet_id,
  lifecycle_state as state
from
  oci_network_firewall_firewall;
[
 {
  "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
  "display_name": "firewall-20230602-2053",
  "id": "ocid1.networkfirewall.oc1.ap-mumbai-1.amaaaaaa6igdexaatb5ygqgxu21111162ysfgn7fmkymftyluq4eukhhm6uq",
  "ipv4_address": "10.0.115.118",
  "ipv6_address": null,
  "network_firewall_policy_id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufcyb6w5awfb11111ms6quturswqcenvoa",
  "network_security_group_ids": [],
  "state": "CREATING",
  "subnet_id": "ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa11111fbian5ailju4l3pbh5ofxx2eyjzb5zxshsk6cbekauymiiq"
 }
]
```

```sql
> select
  id,
  display_name,
  availability_domain,
  ipv4_address,
  ipv6_address,
  network_firewall_policy_id,
  network_security_group_ids,
  subnet_id,
  lifecycle_state as state
from
  oci_network_firewall_firewall
where
  time_created >= now() - interval '30' day;
[
 {
  "availability_domain": "TvRS:AP-MUMBAI-1-AD-1",
  "display_name": "firewall-20230602-2053",
  "id": "ocid1.networkfirewall.oc1.ap-mumbai-1.amaaaaaa6ig11111tb5ygqgxu2skuim62ysfgn7fmkymftyluq4eukhhm6uq",
  "ipv4_address": "10.0.115.118",
  "ipv6_address": null,
  "network_firewall_policy_id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufc11111awfb45brnms6quturswqcenvoa",
  "network_security_group_ids": [],
  "state": "CREATING",
  "subnet_id": "ocid1.subnet.oc1.ap-mumbai-1.aaaaaaaa74iw4111115ailju4l3pbh5ofxx2eyjzb5zxshsk6cbekauymiiq"
 }
]
```

```sql
> select
  id,
  display_name,
  availability_domain,
  ipv4_address,
  ipv6_address,
  network_firewall_policy_id,
  network_security_group_ids,
  subnet_id,
  lifecycle_state as state
from
  oci_network_firewall_firewall
where
  ipv6_address is not null;
null
```

```sql
> select
    f.display_name as firewall_name,
    f.id as firewall_id,
    p.display_name as policy_display_name,
    p.id as policy_id,
    p.lifecycle_details as policy_lifecycle
from
  oci_network_firewall_firewall as f
  left join oci_network_firewall_policy as p on f.network_firewall_policy_id = p.id;
[
 {
  "firewall_id": "ocid1.networkfirewall.oc1.ap-mumbai-1.amaaaaaa6igdexaatb5ygqgxu2skuim11111gn7fmkymftyluq4eukhhm6uq",
  "firewall_name": "firewall-20230602-2053",
  "policy_display_name": "network_firewall_policy_20230602-2050",
  "policy_id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufcyb6w5111115brnms6quturswqcenvoa",
  "policy_lifecycle": null
 }
]
```

```sql
> select
  id,
  display_name,
  application_lists,
  decryption_profiles,
  decryption_rules,
  ip_address_lists,
  is_firewall_attached,
  mapped_secrets,
  security_rules,
  url_lists,
  lifecycle_state as state
from
  oci_network_firewall_policy;
[
 {
  "application_lists": {
   "app-list-1": [
    {
     "maximumPort": 788,
     "minimumPort": 788,
     "type": "TCP"
    }
   ]
  },
  "decryption_profiles": {
   "description-prof-1": {
    "areCertificateExtensionsRestricted": true,
    "isAutoIncludeAltName": true,
    "isExpiredCertificateBlocked": true,
    "isOutOfCapacityBlocked": false,
    "isRevocationStatusTimeoutBlocked": false,
    "isUnknownRevocationStatusBlocked": true,
    "isUnsupportedCipherBlocked": true,
    "isUnsupportedVersionBlocked": true,
    "isUntrustedIssuerBlocked": true,
    "type": "SSL_FORWARD_PROXY"
   }
  },
  "decryption_rules": [
   {
    "action": "NO_DECRYPT",
    "condition": {
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ]
    },
    "decryptionProfile": null,
    "name": "description-rule-1",
    "secret": null
   }
  ],
  "display_name": "network_firewall_policy_20230602-2050",
  "id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufcyb6w5awfb45br11111uturswqcenvoa",
  "ip_address_lists": {
   "ip-address-list-1": [
    "92.158.1.38"
   ]
  },
  "is_firewall_attached": true,
  "mapped_secrets": {
   "mapped-secret-1": {
    "source": "OCI_VAULT",
    "type": "SSL_INBOUND_INSPECTION",
    "vaultSecretId": "ocid1.vaultsecret.oc1.ap-mumbai-1.amaaaaaa6igdexaadx5l4o64xcdppwfm3o4cay2quv111116f4ypibkjqg5a",
    "versionNumber": 1
   }
  },
  "security_rules": [
   {
    "action": "ALLOW",
    "condition": {
     "applications": [
      "app-list-1"
     ],
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ],
     "urls": [
      "url-list-1"
     ]
    },
    "name": "security-rule-1"
   }
  ],
  "state": "ACTIVE",
  "url_lists": {
   "url-list-1": [
    {
     "pattern": "www.google.com",
     "type": "SIMPLE"
    }
   ]
  }
 }
]
```

```sql
> select
  id,
  display_name,
  application_lists,
  decryption_profiles,
  decryption_rules,
  ip_address_lists,
  is_firewall_attached,
  mapped_secrets,
  security_rules,
  url_lists,
  lifecycle_state as state
from
  oci_network_firewall_policy
where
  time_created >= now() - interval '30' day;
[
 {
  "application_lists": {
   "app-list-1": [
    {
     "maximumPort": 788,
     "minimumPort": 788,
     "type": "TCP"
    }
   ]
  },
  "decryption_profiles": {
   "description-prof-1": {
    "areCertificateExtensionsRestricted": true,
    "isAutoIncludeAltName": true,
    "isExpiredCertificateBlocked": true,
    "isOutOfCapacityBlocked": false,
    "isRevocationStatusTimeoutBlocked": false,
    "isUnknownRevocationStatusBlocked": true,
    "isUnsupportedCipherBlocked": true,
    "isUnsupportedVersionBlocked": true,
    "isUntrustedIssuerBlocked": true,
    "type": "SSL_FORWARD_PROXY"
   }
  },
  "decryption_rules": [
   {
    "action": "NO_DECRYPT",
    "condition": {
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ]
    },
    "decryptionProfile": null,
    "name": "description-rule-1",
    "secret": null
   }
  ],
  "display_name": "network_firewall_policy_20230602-2050",
  "id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufcyb6w5awfb45br11111uturswqcenvoa",
  "ip_address_lists": {
   "ip-address-list-1": [
    "92.158.1.38"
   ]
  },
  "is_firewall_attached": true,
  "mapped_secrets": {
   "mapped-secret-1": {
    "source": "OCI_VAULT",
    "type": "SSL_INBOUND_INSPECTION",
    "vaultSecretId": "ocid1.vaultsecret.oc1.ap-mumbai-1.amaaaaaa6igdexaadx5l4o64xcdppwfm3o4ca11111k4nzv6f4ypibkjqg5a",
    "versionNumber": 1
   }
  },
  "security_rules": [
   {
    "action": "ALLOW",
    "condition": {
     "applications": [
      "app-list-1"
     ],
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ],
     "urls": [
      "url-list-1"
     ]
    },
    "name": "security-rule-1"
   }
  ],
  "state": "ACTIVE",
  "url_lists": {
   "url-list-1": [
    {
     "pattern": "www.google.com",
     "type": "SIMPLE"
    }
   ]
  }
 }
]
```

```sql
> select
  id,
  display_name,
  application_lists,
  decryption_profiles,
  decryption_rules,
  ip_address_lists,
  is_firewall_attached,
  mapped_secrets,
  security_rules,
  url_lists,
  lifecycle_state as state
from
  oci_network_firewall_policy
where
  is_firewall_attached;
[
 {
  "application_lists": {
   "app-list-1": [
    {
     "maximumPort": 788,
     "minimumPort": 788,
     "type": "TCP"
    }
   ]
  },
  "decryption_profiles": {
   "description-prof-1": {
    "areCertificateExtensionsRestricted": true,
    "isAutoIncludeAltName": true,
    "isExpiredCertificateBlocked": true,
    "isOutOfCapacityBlocked": false,
    "isRevocationStatusTimeoutBlocked": false,
    "isUnknownRevocationStatusBlocked": true,
    "isUnsupportedCipherBlocked": true,
    "isUnsupportedVersionBlocked": true,
    "isUntrustedIssuerBlocked": true,
    "type": "SSL_FORWARD_PROXY"
   }
  },
  "decryption_rules": [
   {
    "action": "NO_DECRYPT",
    "condition": {
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ]
    },
    "decryptionProfile": null,
    "name": "description-rule-1",
    "secret": null
   }
  ],
  "display_name": "network_firewall_policy_20230602-2050",
  "id": "ocid1.networkfirewallpolicy.oc1.ap-mumbai-1.amaaaaaa6igdexaaykejpv4rnrufcyb6w5awfb11111ms6quturswqcenvoa",
  "ip_address_lists": {
   "ip-address-list-1": [
    "92.158.1.38"
   ]
  },
  "is_firewall_attached": true,
  "mapped_secrets": {
   "mapped-secret-1": {
    "source": "OCI_VAULT",
    "type": "SSL_INBOUND_INSPECTION",
    "vaultSecretId": "ocid1.vaultsecret.oc1.ap-mumbai-1.amaaaaaa6igdexaadx5l4o64xcdppw11111cay2quvk4nzv6f4ypibkjqg5a",
    "versionNumber": 1
   }
  },
  "security_rules": [
   {
    "action": "ALLOW",
    "condition": {
     "applications": [
      "app-list-1"
     ],
     "destinations": [
      "ip-address-list-1"
     ],
     "sources": [
      "ip-address-list-1"
     ],
     "urls": [
      "url-list-1"
     ]
    },
    "name": "security-rule-1"
   }
  ],
  "state": "ACTIVE",
  "url_lists": {
   "url-list-1": [
    {
     "pattern": "www.google.com",
     "type": "SIMPLE"
    }
   ]
  }
 }
]
```

```sql
> select
  id,
  display_name,
  application_lists,
  decryption_profiles,
  decryption_rules,
  ip_address_lists,
  is_firewall_attached,
  mapped_secrets,
  security_rules,
  url_lists,
  lifecycle_state as state
from
  oci_network_firewall_policy
where
  mapped_secrets is null;
null
```
</details>
