### PR TITLE
Added more example queried in the oci_nosql_table doc for counting the number of child table of a parent table

### DIFF
--- a/docs/tables/oci_nosql_table.md
+++ b/docs/tables/oci_nosql_table.md
@@ -43,3 +43,32 @@ from
 where
   cast(table_limits -> 'maxStorageInGBs' as INTEGER) > 1024;
 ```
+
+### Count child tables for parent tables with children
+
+```sql
+select
+ t2.name as parent,
+ count(t1.*) as child_count
+from
+ oci_nosql_table t1
+  join oci_nosql_table t2
+  on t1.title like t2.title || '.%'
+  and t1.title <> t2.title
+group by
+ parent;
+```
+
+### Count child tables for parent tables with and without children
+
+```sql
+select
+ t2.name as parent,
+ count(t1.*) - 1 as child_count
+from
+ oci_nosql_table t1
+  join oci_nosql_table t2
+  on t1.title like t2.title || '%'
+group by
+ parent;
+```


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
 t2.name as parent,
 count(t1.*) as child_count
from
 oci_nosql_table t1
  join oci_nosql_table t2
  on t1.title like t2.title || '.%'
group by
 parent;
+---------------+-------------+
| parent        | child_count |
+---------------+-------------+
| test_a        | 3           |
| test_a.test_b | 1           |
+---------------+-------------+

> select
 t2.name as parent,
 count(t1.*) - 1 as child_count
from
 oci_nosql_table t1
  join oci_nosql_table t2
  on t1.title like t2.title || '%'
group by
 parent;
+----------------------+-------------+
| parent               | child_count |
+----------------------+-------------+
| test_a               | 3           |
| test_a.test_b        | 1           |
| test_a.test_b.test_d | 0           |
| test_a.test_c        | 0           |
+----------------------+-------------+
```
</details>
