### PR TITLE
Add CompartmentId to GetNamespaceRequest

### DIFF
--- a/oci/utils.go
+++ b/oci/utils.go
@@ -37,7 +37,9 @@ func getNamespace(ctx context.Context, d *plugin.QueryData, region string) (*nam
 	if err != nil {
 		return nil, err
 	}
-	request := objectstorage.GetNamespaceRequest{}
+	request := objectstorage.GetNamespaceRequest{
+		CompartmentId: &session.TenancyID,
+	}
 
 	response, err := session.ObjectStorageClient.GetNamespace(ctx, request)
 	if err != nil {


### PR DESCRIPTION
Allows for determining the object storage namespace of a foreign tenant in a cross-tenant query scenario

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
